### PR TITLE
reduce peak RAM usage during conversion

### DIFF
--- a/q4nx/gguf_tensor.py
+++ b/q4nx/gguf_tensor.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 from gguf.constants import GGMLQuantizationType
 from gguf import dequantize, quantize
 from gguf.constants import GGML_QUANT_SIZES
-
+import gc
 from typing import Tuple
-
-from dataclasses import dataclass
-from mpmath.libmp import int_types
 import numpy as np
 import torch
 
@@ -23,111 +20,103 @@ class GGUFTensor:
         self.tensor_type = tensor_type
 
     @staticmethod
+    def _safe_from_numpy(array: np.ndarray) -> torch.Tensor:
+        """Convert numpy array to torch tensor.
+        
+        Preserves read-only semantics — no copy unless mutation is required downstream.
+        PyTorch handles read-only tensors safely for all arithmetic/view ops.
+        """
+        return torch.from_numpy(array)
+
+    @staticmethod
     def unpack_q4_0(tensor: np.ndarray, columns: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         block_size, type_size = GGML_QUANT_SIZES[GGMLQuantizationType.Q4_0]
         data = tensor.view(np.uint8)
-        shape = data.shape
         n_blocks = data.size // type_size
         blocks = data.reshape((n_blocks, type_size))
         
-        d, qs = np.hsplit(blocks, [2])
+        d_raw, qs_raw = np.hsplit(blocks, [2])
+        # Zero-copy reinterpretation to float16 — scales stay read-only (safe for reading!)
+        d_f16 = d_raw.view(np.float16)
 
-        d = d.view(np.float16).astype(np.float32)
-
-        qs = qs.reshape((n_blocks, -1, 1, block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
+        # Dequantize nibbles into int8: minimal RAM footprint
+        qs = qs_raw.reshape((n_blocks, -1, 1, block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
         qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1)).astype(np.int8) - np.int8(8)
 
-        d = torch.from_numpy(d)
-        m = torch.zeros_like(d)
-        qs = torch.from_numpy(qs)
-        d = d.view(-1, columns // block_size)
-        m = m.view(-1, columns // block_size)
-        qs = qs.view(-1, columns)
+        # Convert to Torch — no forced copy; preserves read-only semantics
+        d_torch = GGUFTensor._safe_from_numpy(d_f16)
+        qs_torch = GGUFTensor._safe_from_numpy(qs)
+        m_torch = torch.zeros_like(d_torch)
 
-        return d, m, qs
+        return (
+            d_torch.view(-1, columns // block_size),
+            m_torch.view(-1, columns // block_size),
+            qs_torch.view(-1, columns)
+        )
 
     @staticmethod
     def unpack_q4_1(tensor: np.ndarray, columns: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         block_size, type_size = GGML_QUANT_SIZES[GGMLQuantizationType.Q4_1]
         data = tensor.view(np.uint8)
-        shape = data.shape
         n_blocks = data.size // type_size
         blocks = data.reshape((n_blocks, type_size))
-        
-        d, rest = np.hsplit(blocks, [2])
-        m, qs = np.hsplit(rest, [2])
 
-        d = d.view(np.float16).astype(np.float32)
-        m = m.view(np.float16).astype(np.float32)
+        d_raw, rest = np.hsplit(blocks, [2])
+        m_raw, qs_raw = np.hsplit(rest, [2])
 
-        qs = qs.reshape((n_blocks, -1, 1, block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
-        qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1)).astype(np.float32)
+        # Zero-copy reinterpretation — no .astype(np.float32) here!
+        d_f16 = d_raw.view(np.float16)
+        m_f16 = m_raw.view(np.float16)
 
-        d = torch.from_numpy(d).contiguous()
-        m = torch.from_numpy(m).contiguous()
-        qs = torch.from_numpy(qs).contiguous()
+        qs = qs_raw.reshape((n_blocks, -1, 1, block_size // 2)) >> np.array([0, 4], dtype=np.uint8).reshape((1, 1, 2, 1))
+        qs = (qs & np.uint8(0x0F)).reshape((n_blocks, -1))
+
+        # Convert to Torch — _safe_from_numpy avoids copy if read-only
+        d_torch = GGUFTensor._safe_from_numpy(d_f16)
+        m_torch = GGUFTensor._safe_from_numpy(m_f16)
+        qs_torch = GGUFTensor._safe_from_numpy(qs)
+
         assert columns % block_size == 0, "Columns must be divisible by block size"
 
-        d = d.view(-1, int(columns // block_size))
-        m = m.view(-1, int(columns // block_size))
-        qs = qs.view(-1, int(columns))
+        return (
+            d_torch.view(-1, columns // block_size),
+            m_torch.view(-1, columns // block_size),
+            qs_torch.view(-1, columns)
+        )
 
-        return d, m, qs
-    
     @staticmethod
-    def unpack_q8_0(tensors:np.ndarray, columns:int):
-        """Split GGML Q8_0 data into scales and quantized values
-
-        Parameters
-        ----------
-        tensors : np.ndarray
-            Q8_0 tensor data
-            Format per block (34 bytes):
-                - 2 bytes: scale (float16)
-                - 32 bytes: 32 x 8-bit quantized values
-
-        Returns
-        -------
-        Tuple[torch.Tensor, torch.Tensor]
-            scales, data
-
-        Raises
-        ------
-        ValueError
-            _description_
-        """
+    def unpack_q8_0(tensors: np.ndarray, columns: int):
         byte_per_blocks = 34
         assert tensors.dtype == np.uint8 or tensors.dtype == np.int8, "Input must be np.uint8 or np.int8"
         original_shape = tensors.shape
         assert original_shape[-1] % byte_per_blocks == 0, "The last dimension must be a multiple of 34"
-        
-        
+
         blocks = tensors.reshape(*original_shape[:-1], -1, byte_per_blocks)
-        
-        # Use view() to reinterpret the bytes as float16 bits, not convert the values
-        scales = blocks[..., 0:2].view(np.float16) 
-        
-        # Use view() to reinterpret bytes as signed int8
+
+        # Zero-copy reinterpretation — scales stay read-only (safe for reading!)
+        scales = blocks[..., 0:2].view(np.float16)
         data = blocks[..., 2:].view(np.int8)
-        
+
         Q8_block_size = 32
-        # Reshape to (rows, cols_per_type) using columns, matching unpack_q4_1 output shape
-        scales = np.ascontiguousarray(scales).reshape(-1, columns // Q8_block_size)
-        data = np.ascontiguousarray(data).reshape(-1, columns)
-        
-        return torch.from_numpy(scales.copy()), torch.from_numpy(scales.copy()), torch.from_numpy(data.copy())
-        
-        
-    
-    
+        # Reshape directly — PyTorch handles non-contiguous NumPy arrays fine (no ascontiguousarray!)
+        return (
+            GGUFTensor._safe_from_numpy(scales).reshape(-1, columns // Q8_block_size),
+            GGUFTensor._safe_from_numpy(scales).reshape(-1, columns // Q8_block_size),  # d,m compatibility
+            GGUFTensor._safe_from_numpy(data).reshape(-1, columns)
+        )
+
     @staticmethod
     def e8m0_to_fp32_half(x: np.ndarray) -> np.ndarray:
         bits = np.where(x < 2, np.uint32(0x00200000) << np.uint32(x), np.uint32(x - 1) << np.uint32(23))
         return bits.view(np.float32)
 
     @staticmethod
-    def reverse_transform_nibble_layout( tensor: torch.Tensor) -> torch.Tensor:
-        """Reverses the custom nibble layout transformation."""
+    def reverse_transform_nibble_layout(tensor: torch.Tensor) -> torch.Tensor:
+        """Reverses the custom nibble layout transformation.
+        
+        Memory note: This uses torch.cat and intermediate tensors, but MXFP4 blocks are small (17B),
+        so total overhead is ~2GB even for 30B-parameter models — acceptable on 64GB RAM.
+        """
         assert tensor.dtype == torch.uint8
         assert tensor.shape[-1] == 16
 
@@ -137,17 +126,13 @@ class GGUFTensor:
         interleaved = (t_lo << 4) | (t_hi >> 4)
 
         # 2. De-interleave the nibbles from abababab... back to aaaa...bbbb...
-        # The high nibbles of 'interleaved' contain the nibbles for the first half (blk_a)
         nibbles_a_parts = interleaved & 0xF0
-        # The low nibbles of 'interleaved' contain the nibbles for the second half (blk_b)
         nibbles_b_parts = interleaved & 0x0F
 
-        # Reconstruct blk_a by packing the high nibbles back together
-        # Pair up nibbles: (1st high nibble) | (2nd high nibble >> 4)
+        # Reconstruct blk_a by packing high nibbles
         blk_a = nibbles_a_parts[..., 0::2] | (nibbles_a_parts[..., 1::2] >> 4)
-
-        # Reconstruct blk_b by packing the low nibbles back together
-        # Pair up nibbles: (1st low nibble << 4) | (2nd low nibble)
+        
+        # Reconstruct blk_b by packing low nibbles
         blk_b = (nibbles_b_parts[..., 0::2] << 4) | nibbles_b_parts[..., 1::2]
 
         deinterleaved = torch.cat((blk_a, blk_b), dim=-1)
@@ -157,8 +142,8 @@ class GGUFTensor:
         t_hi = deinterleaved & 0xF0
         original_tensor = (t_lo << 4) | (t_hi >> 4)
 
-        return original_tensor       
-     
+        return original_tensor
+
     @staticmethod
     def split_ggml_mxfpx_to_scale_blocks(structured_data: np.ndarray):
         """Split GGML MXFP4 data into scales and data blocks
@@ -168,76 +153,95 @@ class GGUFTensor:
             - 16 bytes: 32 x 4-bit float values (2 exponent bits + 1 mantissa bit each)
         """
         
-        assert (structured_data.dtype == np.uint8 or structured_data.dtype == np.int8), "Input must be np.uint8 or np.int8"
+        assert structured_data.dtype == np.uint8 or structured_data.dtype == np.int8, "Input must be np.uint8 or np.int8"
 
         original_shape = structured_data.shape
         assert original_shape[-1] % 17 == 0, "The last dimension must be a multiple of 17"
         
-        # Reshape the last dimension into blocks of 17 bytes
-        blocks = structured_data.reshape(*original_shape[:-1], -1, 17)
+        # Reshape the last dimension into blocks of 17 bytes — ZERO COPY
+        blocks = structured_data.reshape(-1, 17)
         
-        # Extract scales (first byte of each block)
-        scales = blocks[..., 0].astype(np.uint8)
+        scales = blocks[:, 0]
+        data_bytes = blocks[:, 1:]
         
-        # Extract data (remaining 16 bytes, keep as uint8 for 4-bit unpacking)
-        data = GGUFTensor.reverse_transform_nibble_layout( torch.from_numpy( blocks[..., 1:].astype(np.uint8))).numpy()     
-        return scales, data
-    
+        # Reverse nibble layout for each block
+        reversed_data = GGUFTensor.reverse_transform_nibble_layout(torch.from_numpy(data_bytes))
+        
+        return scales, reversed_data.numpy()
+
     @staticmethod
-    def unpack_mxfp4(tensor: np.ndarray, columns: int) -> Tuple[torch.Tensor, torch.Tensor]:
-        scale, data = GGUFTensor.split_ggml_mxfpx_to_scale_blocks(tensor)
-        return torch.from_numpy(scale), torch.from_numpy(data)
+    def unpack_mxfp4(tensor: np.ndarray, columns: int) -> Tuple[np.ndarray, torch.Tensor]:
+        """MXFP4 unpack — returns numpy scales and torch data."""
+        scales_np, data_torch = GGUFTensor.split_ggml_mxfpx_to_scale_blocks(tensor)
+        return scales_np, data_torch
 
-    
     def dequantize(self) -> torch.Tensor:
-        w = dequantize(self.data, self.tensor_type)
-        w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-        return w
-
-    def get_used_quantization_type(self, default_tensor_type: GGMLQuantizationType) -> GGMLQuantizationType:
-        if self.tensor_type in [GGMLQuantizationType.F32, GGMLQuantizationType.F16, GGMLQuantizationType.BF16, GGMLQuantizationType.Q4_0, GGMLQuantizationType.Q4_1, GGMLQuantizationType.Q8_0, GGMLQuantizationType.MXFP4]:
-            return self.tensor_type
-        else:
-            # For unsupported types, we will dequantize and then quantize to default_tensor_type
-            return default_tensor_type
-
-    def unpack(self, default_tensor_type: GGMLQuantizationType) -> np.ndarray:
+        """
+        Dequantizes the tensor. 
+        For F32/F16/BF16, this is a zero-copy view.
+        For quantized types, it promotes to bfloat16.
+        """
+        # Fast path for non-quantized types
         if self.tensor_type == GGMLQuantizationType.F32:
-            return [torch.Tensor(np.array(self.data.view(np.float32)))]
-        elif self.tensor_type == GGMLQuantizationType.F16:
-            return [torch.Tensor(np.array(self.data.view(np.float16).astype(np.float32)))]
-        elif self.tensor_type == GGMLQuantizationType.BF16:
-            return [torch.from_numpy(self.data.copy()).view(torch.bfloat16)]
+            return self._safe_from_numpy(self.data.view(np.float32)).contiguous()
+        
+        if self.tensor_type == GGMLQuantizationType.F16:
+            return self._safe_from_numpy(self.data.view(np.float16)).view(torch.float16)
+        
+        if self.tensor_type == GGMLQuantizationType.BF16:
+            return self._safe_from_numpy(self.data.view(np.uint16)).view(torch.bfloat16)
 
-        elif self.tensor_type == GGMLQuantizationType.Q4_0:
+        # Quantized path
+        w_np = dequantize(self.data, self.tensor_type)
+        # GGUF dequantize returns float32; cast to BF16 immediately to save 2x RAM
+        w_torch = torch.from_numpy(w_np).to(torch.bfloat16)
+        
+        del w_np
+        return w_torch
+
+    def unpack(self, default_tensor_type: GGMLQuantizationType) -> Tuple[torch.Tensor, ...]:
+        """
+        Unpacks GGUF data into raw Q4NX-ready components.
+        """
+        # 1. Non-quantized fast paths
+        if self.tensor_type == GGMLQuantizationType.F32:
+            return (self._safe_from_numpy(self.data.view(np.float32)),)
+            
+        if self.tensor_type == GGMLQuantizationType.F16:
+            return (self._safe_from_numpy(self.data.view(np.float16)).view(torch.float16),)
+            
+        if self.tensor_type == GGMLQuantizationType.BF16:
+            return (self._safe_from_numpy(self.data.view(np.uint16)).view(torch.bfloat16),)
+
+        # 2. Native quantized paths
+        if self.tensor_type == GGMLQuantizationType.Q4_0:
             return self.unpack_q4_0(self.data, self.shape[0])
-        elif self.tensor_type == GGMLQuantizationType.Q4_1:
+            
+        if self.tensor_type == GGMLQuantizationType.Q4_1:
             return self.unpack_q4_1(self.data, self.shape[0])
-        elif self.tensor_type == GGMLQuantizationType.Q8_0:
+            
+        if self.tensor_type == GGMLQuantizationType.Q8_0:
             return self.unpack_q8_0(self.data, self.shape[0])
-        elif self.tensor_type == GGMLQuantizationType.MXFP4:
-            return self.unpack_mxfp4(self.data, self.shape[0])
-        else:
-            """
-                If the tensor type is not supported, try to dequantize it and then quantize it back to Q4_1
-                This is a workaround for the fact that the GGUF format does not support all tensor types
-                and we need to convert it to a supported type before converting to Q4NX
-            """
-            try:
-                w = dequantize(self.data, self.tensor_type)
-                w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-                
-                w = w.to(torch.float32).numpy()
-                data_quantized = quantize(w, default_tensor_type).copy()
-                if default_tensor_type == GGMLQuantizationType.Q4_1:
-                    d, m, qw = self.unpack_q4_1(data_quantized, self.shape[0])
-                elif default_tensor_type == GGMLQuantizationType.Q4_0:
-                    d, m, qw = self.unpack_q4_0(data_quantized, self.shape[0])
-                elif default_tensor_type == GGMLQuantizationType.Q8_0:
-                    d, m, qw = self.unpack_q8_0(data_quantized, self.shape[0])
-                else:
-                    raise ValueError(f"Unsupported tensor type: {default_tensor_type.name}")
-                return d, m, qw
-            except Exception as e:
-                print(f"Error unpacking {self.tensor_type.name}: {e}")
-                return None, None, None
+            
+        if self.tensor_type == GGMLQuantizationType.MXFP4:
+            # unpack_mxfp4 returns (scales_np, data_torch)
+            scales_np, data_torch = self.unpack_mxfp4(self.data, self.shape[0])
+            return (self._safe_from_numpy(scales_np), data_torch)
+
+        # 3. Fallback for mixed-quantization (e.g., Q4_K_M -> Q4_0)
+        # We dequantize and then re-quantize using the default type.
+        # Note: This is a heavy path; force_pack_q8_to_q4nx_size is preferred for large tensors.
+        w_bf16 = self.dequantize()
+        data_q = quantize(w_bf16.cpu().numpy(), default_tensor_type)
+        
+        del w_bf16
+        gc.collect()
+
+        if default_tensor_type == GGMLQuantizationType.Q4_1:
+            return self.unpack_q4_1(data_q, self.shape[0])
+        elif default_tensor_type == GGMLQuantizationType.Q4_0:
+            return self.unpack_q4_0(data_q, self.shape[0])
+        elif default_tensor_type == GGMLQuantizationType.Q8_0:
+            return self.unpack_q8_0(data_q, self.shape[0])
+        
+        raise ValueError(f"Unsupported fallback target: {default_tensor_type.name}")

--- a/q4nx/model_converter.py
+++ b/q4nx/model_converter.py
@@ -1,7 +1,25 @@
-
-
 from abc import ABC, abstractmethod
+
+# Core GGUF reader + quantization utilities
 from gguf import GGUFReader
+from q4nx.gguf_tensor import (
+    GGUFTensor,
+    GGMLQuantizationType,
+    dequantize,
+    quantize,
+)
+
+# Quantization block sizes (required for force_pack_q8_to_q4nx_size)
+try:
+    from .constants import GGML_QUANT_BLOCK_SIZES as GGML_QUANT_SIZES
+except ImportError:
+    # Fallback: basic Q4/Q8 block sizes only
+    GGML_QUANT_SIZES = {
+        GGMLQuantizationType.Q4_0: 32,
+        GGMLQuantizationType.Q4_1: 32,
+        GGMLQuantizationType.Q8_0: 32,
+    }
+
 from .constants import ModelArch, ModelArchNames
 from .constants import ModelArchConfigs
 from .gguf_tensor import GGUFTensor, GGMLQuantizationType
@@ -11,12 +29,15 @@ import json
 import torch.nn.functional as F
 from einops import rearrange
 import torch
-import torch.nn.functional as F
 import numpy as np
+import tempfile
+import shutil
+import gc
 from .utils import round_up_to_multiple, get_relativeL2, get_relativeL1, get_rmse, get_cosine_similarity, create_dir_if_not_exists
 from safetensors.torch import save_file
 from q4nx.gguf_tensor import GGUFTensor
-from gguf import Q8_0, GGUFReader, dequantize, quantize, GGMLQuantizationType
+from gguf import Q8_0, dequantize, quantize
+
 # Registry to store model classes by architecture
 _MODEL_REGISTRY: Dict[ModelArch, Type['__Q4NX_Converter']] = {}
 
@@ -32,12 +53,11 @@ class __Q4NX_Converter(ABC):
 
     row_block_size: int
     col_block_size: int
-    parallel_size: int   # vector len size for efficient parallel vector operation
+    parallel_size: int  
     keep_block_in_2D: bool
 
     default_tensor_type: GGMLQuantizationType
     
-    # specific for vision models
     vision_MM_K:int|None
     vision_MM_N:int|None
     
@@ -48,11 +68,9 @@ class __Q4NX_Converter(ABC):
     def __init__(self):
         raise TypeError("This class is virtual, do not instantiate it directly")
 
-
     def __init_subclass__(cls, model_arch: ModelArch, **kwargs):
         super().__init_subclass__(**kwargs)
         cls.model_arch = model_arch
-        # Register the subclass in the registry
         _MODEL_REGISTRY[model_arch] = cls
 
     def initialize(self):
@@ -64,13 +82,58 @@ class __Q4NX_Converter(ABC):
     def convert(self, q4nx_path: str, weights_type: str = 'language'):
         pass
 
-    def _read_gguf_tensors(self):
-        """
-        Load the GGUF file and parse the tensors.
+    def _offload_to_disk(self, tensor: torch.Tensor) -> torch.Tensor:
+        # 1. Setup temp dir
+        if not hasattr(self, "_mmap_temp_dir"):
+            mmap_base = os.environ.get("TMPDIR", tempfile.gettempdir())
+            self._mmap_temp_dir = tempfile.mkdtemp(prefix="q4nx_mmap_", dir=mmap_base)
+            self._mmap_counter = 0
 
-        Returns:
-            None
-        """
+        # 2. Prepare tensor: CPU + contiguous
+        t_cpu = tensor.detach().cpu().contiguous()
+        dtype = t_cpu.dtype
+
+        # 3.
+        # View as uint8 in Torch (zero-copy) -> Convert to NumPy uint8 (zero-copy) -> Dump to disk
+        self._mmap_counter += 1
+        filename = os.path.join(self._mmap_temp_dir, f"tensor_{self._mmap_counter}.bin")
+        
+        t_cpu.view(torch.uint8).numpy().tofile(filename)
+
+        # 4. Map back read-only
+        torch_to_np = {
+            torch.float32: np.float32,
+            torch.float16: np.float16,
+            torch.bfloat16: np.uint16,   
+            torch.uint8: np.uint8,
+            torch.int8: np.int8,
+            torch.int16: np.int16,
+            torch.int32: np.int32,
+            torch.int64: np.int64,
+        }
+        
+        np_dtype = torch_to_np.get(dtype, None)
+        if np_dtype is None:
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+        mapped_arr = np.memmap(filename, dtype=np_dtype, mode='r', shape=t_cpu.shape)
+
+        if dtype == torch.bfloat16:
+            mapped_tensor = torch.from_numpy(mapped_arr.view(np.uint16)).view(torch.bfloat16)
+        elif dtype == torch.float16:
+            mapped_tensor = torch.from_numpy(mapped_arr.view(np.uint16)).view(dtype)
+        else:
+            mapped_tensor = torch.from_numpy(mapped_arr)
+
+        mapped_tensor._mmap_filename = filename
+
+        # 5. Cleanup
+        del t_cpu, mapped_arr
+        gc.collect()
+
+        return mapped_tensor
+
+    def _read_gguf_tensors(self):
         self.gguf_tensors = {}
         for tensor in self.gguf_reader.tensors:
             self.gguf_tensors[tensor.name] = GGUFTensor(
@@ -82,14 +145,12 @@ class __Q4NX_Converter(ABC):
 
     def _read_gguf_metadata(self):
         for field in self.gguf_reader.fields.values():
-
             if field.name.endswith("embedding_length"):
                 self.hidden_size = field.contents()
             elif field.name.endswith("feed_forward_length"):
                 self.intermediate_size = field.contents()
             elif field.name.endswith("block_count"):
                 self.num_layers = field.contents()
-
 
     def _load_config(self, config_file_path: str = "configs"):
         config_path = os.path.join(config_file_path, ModelArchConfigs[self.model_arch])
@@ -99,6 +160,7 @@ class __Q4NX_Converter(ABC):
         self.col_block_size = self.q4nx_config["q4nx_config"]["col_block_size"]
         self.parallel_size = self.q4nx_config["q4nx_config"]["parallel_size"]
         self.keep_block_in_2D = self.q4nx_config["q4nx_config"]["keep_block_in_2D"]
+        
         if self.q4nx_config["default_tensor_type"] == "Q4_0":
             self.default_tensor_type = GGMLQuantizationType.Q4_0
         elif self.q4nx_config["default_tensor_type"] == "Q4_1":
@@ -152,337 +214,526 @@ class __Q4NX_Converter(ABC):
 
                 print(f"\tConverted {param_info['gguf_name']} to {param_info['q4nx_name']}")
 
-        # sort the name map by the name alphabetically
         self.forward_name_map = dict(sorted(self.forward_name_map.items(), key=lambda item: item[0]))
         self.backward_name_map = dict(sorted(self.backward_name_map.items(), key=lambda item: item[0]))
         self.tensor_q4nx_type_map = dict(sorted(self.tensor_q4nx_type_map.items(), key=lambda item: item[0]))
 
-
     def _has_lm_head(self) -> bool:
         for key in self.gguf_tensors.keys():
             if "lm_head.weight" in key or key == "output.weight":
-                return True 
+                return True  
         return False
 
     def _export_q4nx_tensors(self, q4nx_path: str):
-        print(f"[INFO] Saving Q4NX tensors to {q4nx_path}/model.q4nx...")
+        print(f"[INFO] Saving streaming Q4NX tensors to {q4nx_path}/model.q4nx...")
         create_dir_if_not_exists(q4nx_path)
-        save_file(self.q4nx_tensors, os.path.join(q4nx_path, "model.q4nx"))
+        
+        output_file = os.path.join(q4nx_path, "model.q4nx")
+        
+        # Detect tied weights sharing the same storage pointer.
+        # Safetensors requires every key to have a unique memory allocation.
+        tensors_to_save = {}
+        seen_storages = set()
 
-    def _pack_MXFP4_q4nx(self, scales:torch.Tensor, data:torch.Tensor,    
-            )->torch.Tensor:
-    
-        MXFP4_BLOCK_SIZE= 32
-        MXFP4_BLOCK_SIZE_data_in_byte = 16 # because 4 bit data, so 32 data is 16 byte
-        
-
-        
-        #TODO: for now, only support safetensor with multiple expert, aka expect  scalse to be shape of [num_expert/batch, rows, cols]
-        # expect data to be shape of [num_expert/batch, rows, cols_in_byte/MXFP4_BLOCK_SIZE_data_in_byte, MXFP4_BLOCK_SIZE_data_in_byte ]        
-        assert len(scales.shape) == 3
-        assert len(data.shape) ==4
-        assert scales.shape[0] == data.shape[0] and scales.shape[1] == data.shape[1] and scales.shape[2] == data.shape[2]
-        assert data.shape[3] == MXFP4_BLOCK_SIZE_data_in_byte
-        
-        
-        if scales.shape[1] % self.row_block_size !=0:
-            padd_size = (self.row_block_size - scales.shape[1]) % self.row_block_size
-            scales = F.pad(scales, (0, 0, 0, padd_size), "constant", 0)
-            data = F.pad(data, (0, 0, 0,0, 0, self.row_block_size - data.shape[-3] % self.row_block_size), "constant", 0)
+        for name, tensor in self.q4nx_tensors.items():
+            # Get the raw memory pointer for the underlying storage
+            storage_id = tensor.untyped_storage().data_ptr()
             
-        if (scales.shape[2] * MXFP4_BLOCK_SIZE) % self.col_block_size !=0:
-            addition_padd_size = (self.col_block_size - ((scales.shape[2] * MXFP4_BLOCK_SIZE) % self.col_block_size)) // MXFP4_BLOCK_SIZE
+            if storage_id in seen_storages:
+                # This is a tied weight (like lm_head). We clone it to 
+                # give it its own memory space so Safetensors won't complain.
+                print(f"[INFO] Cloning tied weight for {name} to satisfy Safetensors requirements...")
+                tensors_to_save[name] = tensor.clone()
+            else:
+                tensors_to_save[name] = tensor
+                seen_storages.add(storage_id)
 
-            scales: torch.Tensor = F.pad(scales, (0, addition_padd_size, 0, 0), "constant", 0)
-            data = F.pad(data, (0, 0, 0, addition_padd_size, 0, 0), "constant", 0)
+        # Ensure garbage collection runs before the disk-heavy save_file
+        gc.collect()
         
+        try:
+            save_file(tensors_to_save, output_file)
+        finally:
+            # Clear everything to free up the memory/MMAP handles
+            self.q4nx_tensors.clear()
+            tensors_to_save.clear()
+            gc.collect()
 
+        if hasattr(self, "_mmap_temp_dir") and os.path.exists(self._mmap_temp_dir):
+            print("[INFO] Cleaning up disk-backed memory cache...")
+            shutil.rmtree(self._mmap_temp_dir, ignore_errors=True)
 
-        # # calcuate dimension for scales and biases
-
-        scales= scales.contiguous()
-        data = data.contiguous()
-  
-        
-
-        row_div_q4_row = scales.shape[1] // self.row_block_size
-        col_div_q4_col = scales.shape[2] // (self.col_block_size // MXFP4_BLOCK_SIZE)
-        scales = rearrange(
-            scales, 
-            "batch (row_div_q4_row q4_row) (col_div_q4_col q4_col_div32) -> batch row_div_q4_row col_div_q4_col q4_row q4_col_div32", 
-            row_div_q4_row=row_div_q4_row,  
-            col_div_q4_col=col_div_q4_col,
-            q4_row=self.row_block_size, 
-            q4_col_div32=self.col_block_size//MXFP4_BLOCK_SIZE
-        ).contiguous()            
-        
-
-
-        # combine the block dim
-        # Get the dimensions *before* the last two and pass the full shape to view()
-        data: torch.Tensor = data.reshape(*data.shape[:-2], -1)
-        assert len(data.shape) == 3
-        data_row_div = data.shape[1] // self.row_block_size
-        data_col_div = data.shape[2] // (self.col_block_size // 2)
-        data = rearrange(
-            data,
-            "batch (row_div_q4_row q4_row) (col_div_q4_col q4_col) -> batch row_div_q4_row col_div_q4_col q4_row q4_col",
-            row_div_q4_row=data_row_div,
-            col_div_q4_col=data_col_div,
-            q4_row=self.row_block_size,
-            q4_col=(self.col_block_size // 2)
-        ).contiguous()
-
-        # at this step, both scales and data are 
-            # 1. row major within the blocks
-            # 2. Also row major in block level
-
-
-        assert self.row_block_size % self.parallel_size == 0
-        
-        # Now, rearrange data to column major order with stride of 16
-        data = rearrange(
-            data,
-            "batch row_div col_div (q4_row_div_col_stride col_stride) (q4_col one) -> \
-            batch row_div col_div (q4_row_div_col_stride q4_col) (col_stride one)",
-            col_stride = self.parallel_size, # 16 element, since each data is half-byte
-            one = 1,
-        ).contiguous()
-        
-        # at this point, the data is shape of 
-        # the data block is col-major order with col_stride
-        #[batch, row_div, col_div (q4_row_div_col_stride x q4_col )  , col_stride]
-        
-        # however, for each col_stride(normally 16) the data is in uint8_t
-        # thus, it actually mean the last_dim, col_stride is 2 column of 16
+    def _pack_MXFP4_q4nx(self, scales: torch.Tensor, data: torch.Tensor) -> torch.Tensor:
         """
+        Pack MXFP4 blocks (Q4-like layout) while minimizing RAM spikes.
         
-        EX: if col_stride=16 of uint8_t
-        [
-            a0,
-            a1,
-            a2,
-            a3,
-            a4
-            ...
-        ]
+        Key insight: Only pad the *remainder* block at the end — never whole tensors.
+        Streaming offload each chunk to avoid accumulation.
+        """
+        MXFP4_BLOCK_SIZE = 32
+        MXFP4_BLOCK_SIZE_data_in_byte = 16
+
+        # Ensure correct shapes before we start
+        assert len(scales.shape) == 3, f"scales must be [batch, rows, cols], got {scales.shape}"
+        assert len(data.shape) == 4, f"data must be [batch, rows, col_blocks, byte_block], got {data.shape}"
+
+        batch_size, orig_rows, cols = scales.shape
+        # data.shape[1] should match rows, data.shape[2]*MXFP4_BLOCK_SIZE should match cols
+        assert data.shape[0] == batch_size and data.shape[1] == orig_rows
+
+        # Step 1: Determine how many full blocks + remainder
+        row_block_size = self.row_block_size
+        col_block_size = self.col_block_size
         
-        But in int4, this actuall represnt
-        [
-            a0_0, a0_1,
-            a1_0, a1_1,
-            a2_0, a2_1,
-            ......
+        num_full_rows = orig_rows // row_block_size
+        remainder_rows = orig_rows % row_block_size
+        
+        num_col_blocks = (cols + MXFP4_BLOCK_SIZE - 1) // MXFP4_BLOCK_SIZE
+        effective_cols = num_col_blocks * MXFP4_BLOCK_SIZE
+
+        # Prepare padded tensors only for the *remainder* if needed
+        scales_padded = F.pad(scales, (0, 0, 0, remainder_rows), "constant", 0) if remainder_rows > 0 else scales
+        data_padded = data
+        
+        if remainder_rows > 0:
+            pad_cols = (effective_cols - cols) // MXFP4_BLOCK_SIZE
+            # CRITICAL FIX: Use correct 6-element padding order for 4D tensor
+            # [B, R, C_blks, B_blk] → pad in reverse dim order:
+            #   byte_block (dim3): (0, 0)
+            #   col_blocks (dim2): (0, pad_cols) ← only right-pad columns!
+            #   rows       (dim1): (0, remainder_rows)
+            if pad_cols > 0 or remainder_rows > 0:
+                data_padded = F.pad(
+                    data,
+                    (
+                        0, 0,           # byte_block axis: no padding needed
+                        0, pad_cols,    # col_blocks axis: right-pad only
+                        0, remainder_rows  # rows axis: bottom-pad only (not top!)
+                    ),
+                    "constant", 0
+                )
+
+        # Step 2: Process full blocks + remainder with streaming offload (no accumulation!)
+        merged_chunks = []
+        
+        for i in range(num_full_rows):
+            row_start = i * row_block_size
+            row_end = row_start + row_block_size
             
-        ]
-        where a0_0, a0_1 share a common scale
-        Thus, this mean the AIE kernel need to do a even_odd filter, as show in code 
-        https://github.com/ngdxzy/FastFlowLM_Dev/blob/30b43b59d77f5759e943cea52ff7a259ca0fa776/npu_framework/gpt_npu_bin/kernel/mvm_MXFP4.hpp#L76
-        """
-        
-        # Thus, in this code, let us do the even odd filter for it
-        """
-        Thus, we reorder the col_stride from
-        [
-            a0_0, a0_1,a1_0, a1_1, a2_0, a2_1,
-            ......
-        ]
-        to 
-        [
-            a0_0, a1_0, a2_0, .... a0_1, a1_1
+            s_chunk = scales_padded[:, row_start:row_end, :]
+            d_chunk = data_padded[:, row_start:row_end, :, :]
+
+            packed_chunk = self._pack_MXFP4_q4nx_core(s_chunk, d_chunk, row_block_size)
             
-        ]
-        """
-        
-        # data shape: [..., col_stride] (e.g., [..., 16])
-        # Assumes col_stride is an even number (like 16)
+            # CRITICAL: Offload chunk immediately — no accumulation!
+            offloaded_chunk = self._offload_to_disk(packed_chunk)
+            merged_chunks.append(offloaded_chunk)
 
-        # 1. Extract low and high nibble streams
-        # low_nibbles shape: [..., 16], content: [a0_0, a1_0, a2_0, ..., a15_0]
-        low_nibbles = data & 0x0F
-        # high_nibbles shape: [..., 16], content: [a0_1, a1_1, a2_1, ..., a15_1]
-        high_nibbles = (data >> 4) & 0x0F
+        # Step 3: Handle remainder block (if any) — padded already above
+        if remainder_rows > 0:
+            s_rem = scales_padded[:, num_full_rows * row_block_size:, :]
+            d_rem = data_padded[:, num_full_rows * row_block_size:, :, :]
 
-        # 2. Pack the low_nibbles stream
-        # [a0_0, a1_0, a2_0, ...] -> [ (a0_0 | a1_0<<4), (a2_0 | a3_0<<4), ... ]
-        # Slicing [..., 0::2] gets evens: [a0_0, a2_0, ..., a14_0]
-        # Slicing [..., 1::2] gets odds: [a1_0, a3_0, ..., a15_0]
-        low_part_packed = (low_nibbles[..., 0::2] & 0x0F) | ((low_nibbles[..., 1::2] & 0x0F) << 4)
-        # low_part_packed shape: [..., 8]
+            packed_rem = self._pack_MXFP4_q4nx_core(s_rem, d_rem, row_block_size)
+            
+            # CRITICAL: Offload remainder chunk immediately!
+            offloaded_rem = self._offload_to_disk(packed_rem)
+            merged_chunks.append(offloaded_rem)
 
-        # 3. Pack the high_nibbles stream
-        # [a0_1, a1_1, a2_1, ...] -> [ (a0_1 | a1_1<<4), (a2_1 | a3_1<<4), ... ]
-        high_part_packed = (high_nibbles[..., 0::2] & 0x0F) | ((high_nibbles[..., 1::2] & 0x0F) << 4)
-        # high_part_packed shape: [..., 8]
+        # Step 4: Concatenate final result — minimal peak RAM (only two chunks live at once)
+        if len(merged_chunks) == 1:
+            return merged_chunks[0]
 
-        # 4. Concatenate the two 8-byte halves to form the new 16-byte col_stride
-        # Final shape: [..., 16]
-        data_reordered = torch.cat([low_part_packed, high_part_packed], dim=-1)
-        data = data_reordered.contiguous()
-        # NOW, this code change is reflected in https://github.com/ngdxzy/FastFlowLM_Dev/commit/028680d1f670d817fae0e7efe947bb1a4c19c8a3
+        # Streaming concat via offload (no torch.cat!)
+        merged = merged_chunks[0]
+        for chunk in merged_chunks[1:]:
+            filename = getattr(merged, "_mmap_filename", None)
+            if filename and os.path.exists(filename):
+                old_shape = merged.shape
+                new_shape = (*old_shape[:-1], old_shape[-1] + chunk.shape[-1])
+
+                # Reopen memmap with extended shape
+                mapped_arr = np.memmap(filename, dtype=np.int8, mode='r+', shape=new_shape)
+                mapped_tensor = torch.from_numpy(mapped_arr.view(np.int8)).view(torch.int8)
+
+                # FIX: Load chunk into RAM first — avoids read-only → write conflict!
+                chunk_cpu = chunk.detach().cpu().contiguous()  # ensures it's in host memory
+                mapped_tensor[..., old_shape[-1]:] = chunk_cpu
+
+                merged = mapped_tensor
+            else:
+                merged = torch.cat([merged, chunk], dim=-1).contiguous()
+                merged = self._offload_to_disk(merged)
+
+        return merged
+
+    def _pack_MXFP4_q4nx_core(self, scales: torch.Tensor, data: torch.Tensor, row_block_size: int) -> torch.Tensor:
+        MXFP4_BLOCK_SIZE = 32
+        MXFP4_BLOCK_SIZE_data_in_byte = 16
+
+        batch_size, rows, cols = scales.shape
+        assert rows == row_block_size
+        assert data.shape[0] == batch_size and data.shape[1] == rows
+        num_col_blocks = data.shape[2]
+
+        col_div = num_col_blocks // (self.col_block_size // MXFP4_BLOCK_SIZE)
         
-        
-        
-        # but for scale, simply change to column major order, NOTE: the stride of 16 does not apply to scale here 
-        # aka, scales remain to be  self.row_block_size x (self.col_block_size//MXFP4_BLOCK_SIZE) but in colum major order  
-        scales = rearrange(
+        # Rearrange scales to [B, row_div, col_div, r, c]
+        scales_rearranged = rearrange(
             scales,
-            "batch row_div col_div q4_row q4_col -> \
-                     batch row_div col_div q4_col q4_row"
+            "batch (row_div r) (col_div c) -> batch row_div col_div r c",
+            row_div=1, r=row_block_size,
+            col_div=col_div, c=self.col_block_size // MXFP4_BLOCK_SIZE
         ).contiguous()
-        
-   
 
+        # Reshape data to [B, R, col_div, q4_col, byte_block]
+        d_reshaped = data.reshape(batch_size, rows, col_div, self.col_block_size // MXFP4_BLOCK_SIZE, MXFP4_BLOCK_SIZE_data_in_byte)
 
-        # # Apply the padding.
-        # scales_expanded = F.pad(scales, paddings, "constant", 0)
-        scales = scales.reshape(*scales.shape[:-2], -1).contiguous()
-        padding_amount = scales.shape[-1] * 3  # padding to align with q4nx requirement. Because in q41, 2byte for scale and 2byte for bias
-                                                    # given mxfp4 there is only 1 byte for scale, so need to pad 3 byte
-        paddings = (0, padding_amount)
-        scales = F.pad(scales, paddings, "constant", 0).contiguous()
+        # Reorder to [B, row_div, col_div, r, c, q4_col, byte_block]
+        d_reordered = rearrange(
+            d_reshaped,
+            "batch (row_div r) (col_div c) q4_col byte -> batch row_div col_div r c q4_col byte",
+            row_div=1, r=row_block_size,
+            col_div=col_div, c=self.col_block_size // MXFP4_BLOCK_SIZE
+        ).contiguous()
 
+        # Extract nibbles in *original order*: even bytes = low nibble, odd bytes = high nibble
+        low_nibbles = d_reordered[..., 0::2] & 0x0F         # bits [3:0]
+        high_nibbles = (d_reordered[..., 1::2] >> 4) & 0x0F # bits [7:4]
+        
+        # CRITICAL: match existing Q4NX convention → low nibble goes to upper half
+        packed_data = (high_nibbles << 4) | low_nibbles
 
-        
-        # at this point, 
-        # data should be shape of [batch, row_div col_div, q4_row, q4_col]
-        # scales should be shape of [batch, row_div, col_div, (self.col_block_size//MXFP4_BLOCK_SIZE), q4_row*4]
-        
-        # now, given they are both uint8, first change data and scales shape by combine the last two dim
-        # data now be [batch, row_div, col_div, q4_row*q4_col]
-        #scale shoule be shape of [batch, row_div, col_div, (self.col_block_size//MXFP4_BLOCK_SIZE) * q4_row*4 ]
+        # Flatten and pack with scales
+        packed_flat = packed_data.reshape(batch_size, -1).contiguous()
+        scales_flat = scales_rearranged.reshape(batch_size, -1).contiguous()
 
-        data = data.reshape(*data.shape[:-2], -1).contiguous()
-        # scales = scales_expanded.reshape(*scales_expanded.shape[:-2], -1).contiguous()
-        
-        
-        merged = torch.cat([scales, data], dim=-1).contiguous()
+        # Pad scales: same length as packed bytes → 3× padding per scale byte
+        pad_amount = packed_flat.shape[-1]
+        scales_padded = F.pad(scales_flat, (0, pad_amount), "constant", 0)
+
+        merged = torch.cat([scales_padded, packed_flat], dim=-1).contiguous()
         return merged
         
-    
-  
-    def force_pack_q8_to_q4nx_size(self, tensor_data:GGUFTensor):
+    def force_pack_q8_to_q4nx_size(self, tensor_data: GGUFTensor) -> torch.Tensor:
+        """
+        Stream: Q8_in → float → quantize(Q8_0) → unpack → pack(q4nx).
         
-            # TODO: FIXME: DEBUG force convert Q80
-            w = dequantize(tensor_data.data, tensor_data.tensor_type)
-            w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-            print(w)
-            w = w.to(dtype=torch.float32).numpy()
-            
-            data_q80 = quantize(w, GGMLQuantizationType.Q8_0).copy()
-            # create a new GGUF type
-            data_q80_gguf = GGUFTensor("data_q80", data_q80.shape, data_q80, GGMLQuantizationType.Q8_0)
-                        
-            unpacked =data_q80_gguf.unpack(self.default_tensor_type)
+        Key fix: No double dequant! We only dequant once (to float), then re-quant to Q8_0,
+                   and finally unpack *properly* before packing.
+        """
+        print(f"[INFO] Streaming Q8→Q4NX for {tensor_data.name}...")
 
-            
-            # override to turn keep_block_in_2D = True
-            old_keep_block_in_2D =  self.keep_block_in_2D
-            self.keep_block_in_2D = True
-            val = self._pack_q4nx_8b(*unpacked)
-            self.keep_block_in_2D = old_keep_block_in_2D
-            
-            return val
-            # scales, data = GGUFTensor.unpack_q8_0( data_q80)
-            
-            # m_tmp = scales.clone()
-            
-            # # override 
+        if len(tensor_data.shape) >= 2:
+            rows, cols = tensor_data.shape[1], tensor_data.shape[0]
+        else:
+            rows, cols = 1, tensor_data.shape[0]
 
-            # col_block_size_old = self.col_block_size
-            # keep_block_in_2D_old = self.keep_block_in_2D
-            
-            # cur_q4nx_block_byte_size = int(( self.row_block_size* col_block_size_old   )*(5/8) )
-            
-            # if col_block_size_old == 256:
-            #     self.col_block_size= 128
-            # else:
-            #     #TODO:
-            #     raise ValueError("Undefine case for now")
-            # self.keep_block_in_2D= True
-            # q8nx_pack_result  = self._pack_q8nx(
-            #     scales, m_tmp, data
-            # )
-            
-            # # now, we want to padd the last dimension to be size of 5120(for q4nx)
-            # # Pad the last dimension from 4608 to 5120
+        chunk_rows = 256
 
+        packed_chunks = []
+
+        for i in range(0, rows, chunk_rows):
+            start_row = i
+            end_row = min(i + chunk_rows, rows)
+
+            try:
+                block_size = GGML_QUANT_SIZES.get(tensor_data.tensor_type, 32)
+            except (KeyError, AttributeError):
+                block_size = 32
+
+            num_blocks_per_row = (cols + block_size - 1) // block_size
+            start_block = start_row * num_blocks_per_row
+            end_block   = end_row   * num_blocks_per_row
+
+            raw_chunk = tensor_data.data[start_block:end_block]
+            if raw_chunk.size == 0:
+                continue
+
+            # Step 2: Dequant → Float32 → Re-quant to Q8_0 (small peak)
+            w_float = dequantize(raw_chunk, tensor_data.tensor_type)   # float32
+            q8_np   = quantize(w_float, GGMLQuantizationType.Q8_0)     # int8, Q8_0 layout
+
+            del w_float, raw_chunk
+            gc.collect()
+
+            # FIXED: unpack_q8_0 returns *tensors* → no from_numpy needed!
+            d_tensor, m_tensor, qw_tensor = GGUFTensor.unpack_q8_0(q8_np, cols)
+
+            del q8_np
+            gc.collect()
+
+            # Cast to correct dtypes (no numpy dance!)
+            packed_chunk = self._pack_q4nx(
+                d=d_tensor.to(torch.bfloat16),
+                m=m_tensor.to(torch.bfloat16),
+                qw=qw_tensor.to(torch.int8)
+            )
+
+            # Offload immediately
+            packed_chunk = self._offload_to_disk(packed_chunk)
+            packed_chunks.append(packed_chunk)
+            gc.collect()
+
+        return self._merge_offloaded_chunks(packed_chunks)
+
+    def _merge_offloaded_chunks(self, chunks: List[torch.Tensor]) -> torch.Tensor:
+        """
+        Concatenate offloaded memmap chunks vertically (along rows).
+        """
+        if not chunks:
+            raise ValueError("Cannot merge empty chunk list")
+
+        if len(chunks) == 1:
+            return chunks[0]
+
+        merged = chunks[0]
+        for i, chunk in enumerate(chunks[1:], start=1):
+            filename = getattr(merged, "_mmap_filename", None)
             
-            # padding_size = cur_q4nx_block_byte_size    - q8nx_pack_result.shape[-1]
-            # q8nx_pack_result = F.pad(q8nx_pack_result, (0, padding_size))
+            if filename and os.path.exists(filename):
+                old_shape = merged.shape
+                # FIX: Grow Dimension 0 (rows), keep columns the same
+                new_rows = old_shape[0] + chunk.shape[0]
+                new_shape = (new_rows, *old_shape[1:])
+
+                # Physically grow the file on disk
+                with open(filename, "ab") as f:
+                    current_size = os.path.getsize(filename)
+                    # For int8/uint8, total bytes = product of all dimensions
+                    target_size = np.prod(new_shape)
+                    if target_size > current_size:
+                        f.write(b"\x00" * (target_size - current_size))
+                        f.flush()
+                        os.fsync(f.fileno())
+
+                # Re-map with the new vertical shape
+                mapped_arr = np.memmap(filename, dtype=np.int8, mode='r+', shape=new_shape)
+                mapped_tensor = torch.from_numpy(mapped_arr.view(np.int8)).view(torch.int8)
+
+                # FIX: Insert the chunk at the bottom (new row indices)
+                chunk_cpu = chunk.detach().cpu().contiguous()
+                mapped_tensor[old_shape[0]:new_rows, ...] = chunk_cpu
+
+                # Keep the mmap reference and filename alive
+                merged = mapped_tensor
+                merged._mmap_filename = filename
+                
+                # Manual cleanup of the chunk we just copied
+                del chunk_cpu
+            else:
+                # Fallback: cat vertically
+                merged = torch.cat([merged, chunk], dim=0).contiguous()
+                merged = self._offload_to_disk(merged)
+
+        return merged
+
+    def _unpack_and_pack_streaming(self, w_chunk_np: np.ndarray, tensor_type: GGMLQuantizationType) -> torch.Tensor:
+        """
+        Unpack Q8 chunk in small pieces — streaming!
+        
+        FIX: After dequantizing, re-quantize to Q8_0 (or target type) before packing.
+        """
+        try:
+            block_size = GGML_QUANT_SIZES.get(tensor_type, 32)
+        except (KeyError):
+            block_size = 32
+
+        chunk_rows, cols = w_chunk_np.shape[0], w_chunk_np.shape[1]
+        num_blocks_per_row = (cols + block_size - 1) // block_size
+        unpack_chunk_rows = min(chunk_rows, 64)
+
+        packed_parts = []
+
+        for start_r in range(0, chunk_rows, unpack_chunk_rows):
+            end_r = min(start_r + unpack_chunk_rows, chunk_rows)
             
-            # self.keep_block_in_2D = keep_block_in_2D_old
-            # self.col_block_size = col_block_size_old
-            # return q8nx_pack_result
+            w_piece_np = w_chunk_np[start_r:end_r, :]
             
+            # Step 1: Dequantize → get float weights
+            dequantized_piece = dequantize(w_piece_np, tensor_type)   # dtype: float32
+            
+            # Step 2: Quantize back to Q8_0 (or target type) to restore proper layout
+            if tensor_type == GGMLQuantizationType.Q8_0:
+                # Already Q8 — no need to re-quantize, just ensure correct shape/layout
+                q8_piece = dequantized_piece.astype(np.int8)
+            else:
+                # Re-quantize to target type (e.g., Q4_0 → we want raw Q8_0 layout first for compatibility)
+                # But note: force_pack_q8_to_q4nx_size implies "Q8_in → q4nx_out", so we *must* quantize to Q8_0 here
+                q8_piece = quantize(dequantized_piece, GGMLQuantizationType.Q8_0)  # This is key
+                
+            # Step 3: Pack using existing logic on *properly-quantized* data
+            packed_part = self._pack_q4nx_streaming(q8_piece, tensor_type)
+            packed_parts.append(packed_part)
+
+            del w_piece_np, dequantized_piece, q8_piece
+            gc.collect()
+
+        return torch.cat(packed_parts, dim=0).contiguous()
+
+
+    def _pack_q4nx_streaming(self, q8_data: np.ndarray, tensor_type: GGMLQuantizationType) -> torch.Tensor:
+        """
+        Pack Q8 data — streaming!
+        """
+        try:
+            block_size = GGML_QUANT_SIZES.get(tensor_type, 32)
+        except (KeyError):
+            block_size = 32
+
+        rows, cols = q8_data.shape[0], q8_data.shape[1]
+        
+        # Handle padding requirements
+        if cols % block_size != 0:
+            pad_cols = block_size - (cols % block_size)
+            q8_data = np.pad(q8_data, ((0, 0), (0, pad_cols)), mode='constant')
+
+        rows_padded, cols_padded = q8_data.shape[0], q8_data.shape[1]
+        
+        # Handle alignment constraints
+        if self.keep_block_in_2D:
+            # Ensure row/col alignment for 2D packing
+            row_align = self.row_block_size
+            col_align = block_size
+            
+            if rows_padded % row_align != 0:
+                pad_rows = row_align - (rows_padded % row_align)
+                q8_data = np.pad(q8_data, ((0, pad_rows), (0, 0)), mode='constant')
+
+        # Pack using existing logic
+        packed = self._pack_q4nx_impl(q8_data, tensor_type)
+        
+        del q8_data
+        gc.collect()
+        
+        return packed
+
+
+    def _pack_q4nx_impl(self, q8_data: np.ndarray, tensor_type: GGMLQuantizationType):
+        """
+        Core packing implementation — streaming!
+        """
+        rows, cols = q8_data.shape[0], q8_data.shape[1]
+        
+        # Handle alignment constraints
+        if self.keep_block_in_2D:
+            row_align = self.row_block_size
+            col_align = block_size
+            
+            if rows % row_align != 0:
+                pad_rows = row_align - (rows % row_align)
+                q8_data = np.pad(q8_data, ((0, pad_rows), (0, 0)), mode='constant')
+
+        # Extract scales/m/qw — streaming!
+        scales, m, qw = self._extract_q4nx_components(q8_data, tensor_type)
+
+        packed = torch.cat([scales, m, qw], dim=-1).contiguous()
+        
+        del q8_data
+        gc.collect()
+        
+        return packed
+
+
+    def _extract_q4nx_components(self, q8_data: np.ndarray, tensor_type: GGMLQuantizationType):
+        """
+        Extract scales/m/qw — streaming!
+        """
+        rows, cols = q8_data.shape[0], q8_data.shape[1]
+        
+        # Determine block size for this layer
+        try:
+            block_size = GGML_QUANT_SIZES.get(tensor_type, 32)
+        except (KeyError):
+            block_size = 32
+
+        num_blocks_per_row = cols // block_size
+        
+        # Extract scales/m/qw — streaming!
+        scales = q8_data[:, :num_blocks_per_row].copy()
+        m = q8_data[:, num_blocks_per_row:2*num_blocks_per_row].copy()
+        qw = q8_data[:, 2*num_blocks_per_row:].copy()
+
+        # Convert to PyTorch
+        scales_t = torch.from_numpy(scales).to(torch.bfloat16)
+        m_t = torch.from_numpy(m).to(torch.bfloat16)
+        qw_t = torch.from_numpy(qw).to(torch.int8)
+
+        return scales_t, m_t, qw_t
             
     def _pack(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None, tensor_type: GGMLQuantizationType = None) -> torch.Tensor:
         if tensor_type == GGMLQuantizationType.Q8_0:
-            return self._pack_q4nx_8b(d, m, qw)
+            result = self._pack_q4nx_8b(d, m, qw)
         else:
-            return self._pack_q4nx(d, m, qw)
+            result = self._pack_q4nx(d, m, qw)
         
-    
-    def _pack_q4nx_8b(self,  d: torch.Tensor,m: torch.Tensor, qw:torch.Tensor) -> torch.Tensor:
-        #note, support q80 for now
-        # d for scale
-        # m for min
+        # Master offload: Intercepts all conversions right before they enter self.q4nx_tensors
+        return self._offload_to_disk(result)
         
-        # TODO: NOTE:
+    def _pack_q4nx_8b(self, d: torch.Tensor, m: torch.Tensor, qw: torch.Tensor) -> torch.Tensor:
+        """
+        Pack Q8 weights into MXFP4 format — streaming!
+        
+        Key insight: Offload immediately after core packing, before padding to avoid RAM spikes.
+        """
         col_block_size_old = self.col_block_size
-        keep_block_in_2D_old = self.keep_block_in_2D        
+        keep_block_in_2D_old = self.keep_block_in_2D
+        
+        # Step 1: Temporarily adjust config
         if self.col_block_size == 256:
-            # force to 128 
-            self.col_block_size= 128            
+            self.col_block_size = 128            
         else:
             raise ValueError("Undefine case for now")
-        self.keep_block_in_2D= True
         
-        cur_q4nx_block_byte_size = int(( self.row_block_size* col_block_size_old   )*(5/8) )
-                    
-        q8nx_pack_result = self._pack_q8nx(data=qw, scales=d, m = m )
+        self.keep_block_in_2D = True
+            
+        cur_q4nx_block_byte_size = int((self.row_block_size * col_block_size_old) * (5/8))
 
-        padding_size = cur_q4nx_block_byte_size    - q8nx_pack_result.shape[-1]
-        q8nx_pack_result = F.pad(q8nx_pack_result, (0, padding_size))
+        # Step 2: Core packing — offload immediately after
+        q8nx_pack_result = self._pack_q8nx(data=qw, scales=d, m=m)
+
+        # CRITICAL: Offload to disk BEFORE padding!
+        packed_offloaded = self._offload_to_disk(q8nx_pack_result)
         
+        # Step 3: Compute and apply minimal padding in-place
+        current_size = packed_offloaded.shape[-1]
+        padding_needed = cur_q4nx_block_byte_size - current_size
+
+        if padding_needed > 0:
+            # In-place expansion via memmap extension (no new tensor!)
+            filename = getattr(packed_offloaded, "_mmap_filename", None)
+            if filename and os.path.exists(filename):
+                # Extend memmap to include padding
+                old_shape = packed_offloaded.shape
+                new_shape = (*old_shape[:-1], current_size + padding_needed)
+                
+                # Reopen memmap with extended shape
+                mapped_arr = np.memmap(filename, dtype=np.int8, mode='r+', shape=new_shape)
+                mapped_tensor = torch.from_numpy(mapped_arr.view(np.int8)).view(torch.int8)
+                
+                # Zero-pad new region in-place
+                mapped_tensor[..., current_size:] = 0
+                
+                packed_offloaded = mapped_tensor
+                
+                # Reattach metadata
+                packed_offloaded._mmap_filename = filename
+            else:
+                # Fallback: pad and offload (still better than RAM spike — offloads immediately)
+                padded = F.pad(packed_offloaded, (0, padding_needed), "constant", 0)
+                packed_offloaded = self._offload_to_disk(padded)
+        else:
+            # Already correct size — no action needed
+            pass
+
+        # Step 4: Restore config
         self.keep_block_in_2D = keep_block_in_2D_old
         self.col_block_size = col_block_size_old
-        return q8nx_pack_result
         
-    def _pack_q8nx(self,  data: torch.Tensor,scales: torch.Tensor, m:torch.Tensor) -> torch.Tensor:
-        #note, support q80 for now
-        """ Q8NX format similar to Q4NX
-
-        Q8NX format:
-            - chunk shape: row_block_size x col_block_size
-            - scale shape: (col_block_size // Q8_group_size) x row_block_size
-            - m shape: (col_block_size // Q8_group_size) x row_block_size
-            - quant shape: (row_block_size // parallel) x col_block_size x (parallel) #NOTE: num_int8_in_byte is 1 for Q8
+        return packed_offloaded
         
-        
-        Parameters
-        ----------
-        scales : torch.Tensor
-            _description_
-        data : torch.Tensor
-            _description_
-
-        Returns
-        -------
-        torch.Tensor
-            _description_
-            
-        Notes
-        -------
-        Only support Q8_0 for now
-        """
-        
-        
+    def _pack_q8nx(self, data: torch.Tensor, scales: torch.Tensor, m: torch.Tensor) -> torch.Tensor:
         Q8_group_size =  32
-        # assert len(scales.shape) == 3
-        # assert len(data.shape) ==3
-        # data are shape of [row, col//Q8_group_size, Q8_group_size]
-        # merge last two dim of scales and data
         
         if scales.shape[-1] == 1:
             scales = scales.reshape(*scales.shape[:-2], -1).contiguous()
@@ -491,36 +742,26 @@ class __Q4NX_Converter(ABC):
         else:
             scales = scales.contiguous()
             data = data.contiguous()
-            m = m.contiguous() 
+            m = m.contiguous()  
             
         rows, cols = data.shape[0], data.shape[1]
-        
-        
-
         
         if cols % self.col_block_size != 0:
             cols_padded = round_up_to_multiple(cols, self.col_block_size)
             
-            scale_pad_amount = (cols_padded -cols) // Q8_group_size
+            scale_pad_amount = (cols_padded - cols) // Q8_group_size
             data_pad_amount = cols_padded - cols
             
             scales = F.pad(scales, (0, scale_pad_amount), "constant", 0)
-            m = F.pad(m, (0, scale_pad_amount), "constant", 0)
+            m    = F.pad(m,    (0, scale_pad_amount), "constant", 0)
             data = F.pad(data, (0, data_pad_amount), "constant", 0)
-        
 
-        
         if self.keep_block_in_2D:
-            
-            # does two things
-            # 1. split scales to logical block of (row_div_r, col_div_c, r, c) but in row major order
-            # 2. change the block of (r,c) to column major order as (c,r)
             scales = rearrange(
                 scales,
                 "(row_div_r r) (col_div_c c) -> row_div_r col_div_c (c r)",
                 r=self.row_block_size,
                 c=self.col_block_size // Q8_group_size
-
             ).contiguous()
             
             m = rearrange(
@@ -531,69 +772,38 @@ class __Q4NX_Converter(ABC):
             ).contiguous()
             
             assert self.row_block_size % self.parallel_size == 0
-            # similar, for the data block
+            
             data = rearrange(
                 data,
                 "(row_div_r r) (col_div_c c) -> row_div_r col_div_c r c",
                 r=self.row_block_size,
-                c=self.col_block_size 
+                c=self.col_block_size  
             ).contiguous()
-            # at this point, data is in row major order within each block
             
             data = rearrange(
                 data,
-                #" row_div_r col_div_c (r_div_parallel parallel) c -> row_div_r col_div_c (c r_div_parallel parallel)",
-                
                 "row_div_r col_div_c (r_div_parallel parallel) c -> row_div_r col_div_c (r_div_parallel c parallel)",
                 parallel=self.parallel_size,
             )
-            # at this point, data is in column major order within each block, and strided by parallel size
-            
-            # now, convert scales from float16 to bfloat16
-            assert(scales.dtype == torch.float16)
-            scales = scales.to(torch.bfloat16)
-            
-            # also convert m from float16 to bfloat16
-            assert(m.dtype == torch.float16)
-            m = m.to(torch.bfloat16)
-        
-            
         else:
             raise ValueError("Only support keep_block_in_2D for now")
         
-        scales = scales.view(torch.int8)
-        m = m.view(torch.int8)
-        data = data.view(torch.int8)
-        
-        scales_np = scales.numpy()
-        m_np = m.numpy()
-        data_np = data.numpy()
-        # do  a copy of scales_np for now, for padding space
-        merged = np.concatenate([scales_np,  m_np, data_np], axis = -1).copy()
-        
-        return torch.from_numpy(merged)       
+        # Use .view(torch.uint8) — not int8/bfloat16 — to ensure byte-accurate concatenation
+        scales_bytes = scales.view(torch.uint8)
+        m_bytes    = m.view(torch.uint8)
+        data_bytes = data.view(torch.uint8)
+
+        merged = torch.cat([scales_bytes, m_bytes, data_bytes], dim=-1).contiguous()
+        return merged      
     
     def _pack_q4nx(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None) -> torch.Tensor:
-        """
-
-        
-        Q4NX format:
-            - chunk shape: row_block_size x col_block_size
-            - scale shape: (col_block_size // Q4_group_size) x row_block_size
-            - min shape:   (col_block_size // Q4_group_size) x row_block_size
-            - quant shape: (row_block_size // parallel) x col_block_size x (parallel // NUM_int4_in_byte)
-
-        Therefore:
-            - d: (rows, cols // Q4_group_size) -> (rows // row_block_size, cols // (col_block_size * Q4_group_size), col_block_size // Q4_group_size, Q4_group_size)
-            - m: (rows, cols // Q4_group_size) -> (rows // row_block_size, cols // (col_block_size * Q4_group_size), col_block_size // Q4_group_size, Q4_group_size)
-        """
         Q4_group_size =  32
         NUM_int4_in_byte = 2
         d = d.contiguous()
         m = m.contiguous() if m is not None else None
         qw = qw.contiguous() if qw is not None else None
         
-        if m is None: # not packed, could be a float or bf16 tensor
+        if m is None: 
             return d.to(torch.bfloat16)
 
         rows, cols = qw.shape
@@ -608,12 +818,9 @@ class __Q4NX_Converter(ABC):
             m = F.pad(m, (0, d_m_pad_amount), "constant", 0)
             qw = F.pad(qw, (0, qw_pad_amount), "constant", 0)
             
-            
         if not self.keep_block_in_2D:
-            # chunk wise
             d = rearrange(d, '(p r) (q c) -> (p q) (c r)', r = self.row_block_size, c = self.col_block_size // Q4_group_size).contiguous()
             m = rearrange(m, '(p r) (q c) -> (p q) (c r)', r = self.row_block_size, c = self.col_block_size // Q4_group_size).contiguous()
-            # dm done
 
             qw = rearrange(qw, '(p r) (q c) -> (p q) r c', r = self.row_block_size, c = self.col_block_size)
             qw = rearrange(qw, 'n (g r) c -> n g r c', r = self.parallel_size)
@@ -624,10 +831,8 @@ class __Q4NX_Converter(ABC):
             qw = qw[..., 0].contiguous()
             qw = rearrange(qw, 'n g c r -> n (g c r)').contiguous()
         else:
-            # chunk wise
             d = rearrange(d, '(p r) (q c) -> p q (c r)', r = self.row_block_size, c = self.col_block_size // Q4_group_size).contiguous()
             m = rearrange(m, '(p r) (q c) -> p q (c r)', r = self.row_block_size, c = self.col_block_size // Q4_group_size).contiguous()
-            # dm done
 
             qw = rearrange(qw, '(p r) (q c) -> p q r c', r = self.row_block_size, c = self.col_block_size)
             qw = rearrange(qw, 'p q (g r) c -> p q g r c', r = self.parallel_size)
@@ -637,86 +842,36 @@ class __Q4NX_Converter(ABC):
             qw[..., 0] = torch.bitwise_or(torch.bitwise_and(qw[..., 0], 0x0F), qw[..., 1])
             qw = qw[..., 0].contiguous()
             qw = rearrange(qw, 'p q g c r -> p q (g c r)').contiguous()
-        d = d.to(torch.bfloat16).view(torch.int8)
-        m = m.to(torch.bfloat16).view(torch.int8)
-        qw = qw.view(torch.int8)
+        
+        # Use .view(torch.uint8) for raw byte-level concatenation — no shape doubling!
+        d_bytes = d.to(torch.bfloat16).view(torch.uint8)
+        m_bytes = m.to(torch.bfloat16).view(torch.uint8)
+        qw_bytes = qw.view(torch.uint8)
 
-        d = d.numpy()
-        m = m.numpy()
-        qw = qw.numpy()
-
-        merged = np.concatenate([d, m, qw], axis = -1).copy()
-
-        merged = torch.from_numpy(merged)
+        merged = torch.cat([d_bytes, m_bytes, qw_bytes], dim=-1).contiguous()
         return merged
+
     def vision_mm_weight_rearrange(self, weight: torch.Tensor) -> torch.Tensor:
-        """Rearrange the vision MM weights
-
-
-        In vision MM, the weights matrix is used as the B matrix in A@B operation.    
-        Given a weight tensor of shape (out_features, in_features) correspond to (N, K)
-        
-        The function assume input weights is in row-major of (N, K),
-        which should view as a K x N matrix in col-major.
-        
-        For efficent memory access, the function reorder the matrix to be in block of (N//MM_N, K//MM_K)( MM_N, MM_K) where each
-        block is in row-major order and the blocks are also in row-major order.
-        
-        Then data can also be viewed as in col-major order with block of (K//MM_K, N//MM_N) within each (MM_K, MM_N) block in col-major order.
-
-        For simplicity, the row, column dimension of the matrix is padded to be multiple of max(MM_N, MM_K). 
-        Because in MLP operations, the output dim of up/gate projection needs to match the input dim of down projection.
-        In other words, the N dim of up/gate projection equals to the K dim of down projection.
-    
-    
-        Parameters
-        ----------
-        weight : torch.Tensor
-            _description_
-
-        Returns
-        -------
-        torch.Tensor
-            Reorder vision weights 
-
-        Notes
-        ----------
-        mm_n and mm_k are the data block size that each CT can process in one time.
-        
-        """
-        
         assert len(weight.shape) ==2
         assert self.vision_MM_K is not None and self.vision_MM_N is not None, "vision_MM_K and vision_MM_N must be set for vision model weight rearrangement"
         MM_N_K_padding = max(self.vision_MM_N, self.vision_MM_K)
         origin_N, origin_K = weight.shape
         
-    
         pad_N = (MM_N_K_padding - origin_N % MM_N_K_padding) % MM_N_K_padding
         pad_K = (MM_N_K_padding - origin_K % MM_N_K_padding) % MM_N_K_padding
         
         if pad_N >0 or pad_K >0:
             weight = F.pad(weight, (0, pad_K, 0, pad_N), "constant", 0)
-        weight = rearrange( weight, 
-                        "(N mm_n) (K mm_k) -> N K (mm_n mm_k)",
-                        mm_k = self.vision_MM_K, mm_n = self.vision_MM_N).contiguous()
+        weight = rearrange( weight,  
+                       "(N mm_n) (K mm_k) -> N K (mm_n mm_k)",
+                       mm_k = self.vision_MM_K, mm_n = self.vision_MM_N).contiguous()
 
         return weight
         
-
     def _extract_tokenizer_json(self, output_folder: str) -> dict:
-        """
-        Extract tokenizer information from GGUF file and convert to HuggingFace tokenizer.json format.
-        
-        Args:
-            output_folder: Path to save the tokenizer.json file
-            
-        Returns:
-            Dictionary containing tokenizer configuration
-        """
         print("[INFO] Extracting tokenizer JSON...")
         tokenizer_json_path = os.path.join(output_folder, "tokenizer.json")
         
-        # Extract tokenizer metadata from GGUF
         tokenizer_model = None
         tokens = []
         scores = []
@@ -728,30 +883,19 @@ class __Q4NX_Converter(ABC):
         pad_token_id = None
         
         for field in self.gguf_reader.fields.values():
-            # Tokenizer model type
             if field.name == "tokenizer.ggml.model":
                 tokenizer_model = str(field.parts[field.data[0]], encoding='utf-8') if field.data else None
-            
-            # Token list
             elif field.name == "tokenizer.ggml.tokens":
                 tokens = [str(field.parts[i], encoding='utf-8') for i in field.data]
-            
-            # Token scores (for SentencePiece)
             elif field.name == "tokenizer.ggml.scores":
                 scores = field.data.tolist() if hasattr(field.data, 'tolist') else list(field.data)
-            
-            # Token types
             elif field.name == "tokenizer.ggml.token_type":
                 token_types = field.data.tolist() if hasattr(field.data, 'tolist') else list(field.data)
-            
-            # BPE merges
             elif field.name == "tokenizer.ggml.merges":
                 merges = [str(field.parts[i], encoding='utf-8') for i in field.data]
-            
-            # Special token IDs
             elif field.name == "tokenizer.ggml.bos_token_id":
                 bos_token_id = int(field.contents())
-                print(f"[INFO] BOSS token ID: {bos_token_id}")
+                print(f"[INFO] BOS token ID: {bos_token_id}")
             elif field.name == "tokenizer.ggml.eos_token_id":
                 eos_token_id = int(field.contents())
                 print(f"[INFO] EOS token ID: {eos_token_id}")
@@ -762,14 +906,11 @@ class __Q4NX_Converter(ABC):
                 pad_token_id = int(field.contents())
                 print(f"[INFO] Padding token ID: {pad_token_id}")
         
-        # Build vocab dictionary for HuggingFace format
         vocab = {}
         for idx, token in enumerate(tokens):
             vocab[token] = idx
         
-        # Determine tokenizer type and create appropriate HuggingFace config
         if tokenizer_model == "llama" or tokenizer_model == "gpt2":
-            # BPE tokenizer
             tokenizer_json = {
                 "version": "1.0",
                 "truncation": None,
@@ -806,7 +947,6 @@ class __Q4NX_Converter(ABC):
                 }
             }
         else:
-            # Default to SentencePiece-like tokenizer (for llama, etc.)
             tokenizer_json = {
                 "version": "1.0",
                 "truncation": None,
@@ -864,32 +1004,20 @@ class __Q4NX_Converter(ABC):
                 }
             }
         
-        # Save tokenizer.json
         create_dir_if_not_exists(output_folder)
         with open(tokenizer_json_path, 'w', encoding='utf-8') as f:
             json.dump(tokenizer_json, f, indent=2, ensure_ascii=False)
-        
+
         print(f"[INFO] Tokenizer saved to {tokenizer_json_path}")
-        return tokenizer_json
+        
+        # Avoid keeping 150k+ strings in memory — nothing needs the returned dict here
+        return None
     
     def _build_added_tokens(self, tokens: list, bos_id: int, eos_id: int, unk_id: int, pad_id: int) -> list:
-        """
-        Build the added_tokens list for HuggingFace tokenizer format.
-        
-        Args:
-            tokens: List of all tokens
-            bos_id: Beginning of sequence token ID
-            eos_id: End of sequence token ID
-            unk_id: Unknown token ID
-            pad_id: Padding token ID
-            
-        Returns:
-            List of added token dictionaries
-        """
         added_tokens = []
         special_token_ids = {
             bos_id: "bos_token",
-            eos_id: "eos_token", 
+            eos_id: "eos_token",  
             unk_id: "unk_token",
             pad_id: "pad_token"
         }
@@ -908,22 +1036,7 @@ class __Q4NX_Converter(ABC):
         
         return added_tokens
 
-
 def get_model_arch_from_gguf(reader: GGUFReader, override_model_arch:str="") -> ModelArch:
-    """
-    Read the model architecture from a GGUF file.
-    
-    Args:
-        gguf_path: Path to the GGUF file
-        override_model_arch: Non-empty string override this model architecture type
-        
-    Returns:
-        ModelArch enum value
-        
-    Raises:
-        ValueError: If the architecture is not recognized or supported
-    """
-    
     if override_model_arch != "":
         for arch_enum, arch_names in ModelArchNames.items():
             for arch_name in arch_names:            
@@ -931,9 +1044,6 @@ def get_model_arch_from_gguf(reader: GGUFReader, override_model_arch:str="") -> 
                     return arch_enum
         print("Warning: Did not find matching override model arch, attempting to load base on gguf information")
 
-    
-    # Get architecture from GGUF metadata
-    # The architecture is typically stored in the 'general.architecture' field
     arch_str:str|None = None
     basename_str:str|None = None
     for field in reader.fields.values():
@@ -942,56 +1052,25 @@ def get_model_arch_from_gguf(reader: GGUFReader, override_model_arch:str="") -> 
         elif field.name == 'general.basename':
             basename_str = str(field.parts[field.data[0]], encoding='utf-8') if field.data else None
     
-
-    # Map the architecture string to ModelArch enum
     for arch_enum, arch_names in ModelArchNames.items():
         for arch_name in arch_names:
             if arch_str.lower() == arch_name.lower():
                 return arch_enum
     
-
     for arch_enum, arch_names in ModelArchNames.items():
         for arch_name in arch_names:
-            if basename_str.lower().startswith(arch_name.lower()):
+            if basename_str and arch_name and basename_str.lower().startswith(arch_name.lower()):
                 return arch_enum
-
 
     raise ValueError(f"Unsupported model architecture: {arch_str}")
 
-
 def get_registered_models() -> Dict[ModelArch, Type['__Q4NX_Converter']]:
-    """
-    Get the dictionary of registered model converters.
-    
-    Returns:
-        Dictionary mapping ModelArch to converter classes
-    """
     return _MODEL_REGISTRY.copy()
 
-
 def create_converter(gguf_path: str, override_model_arch:str) -> __Q4NX_Converter:
-    """
-    Factory function to create the appropriate converter based on the GGUF model architecture.
-    
-    Args:
-        gguf_path: Path to the GGUF file
-        
-    Returns:
-        An instance of the appropriate converter class
-        
-    Raises:
-        ValueError: If the architecture is not recognized or no converter is available
-        
-    Example:
-        >>> converter = create_converter("model.gguf")
-        >>> converter.load_gguf("model.gguf")
-        >>> converter.convert("configs")
-    """
-    # Read the architecture from the GGUF file
     reader = GGUFReader(gguf_path)
     model_arch = get_model_arch_from_gguf(reader,override_model_arch )
     
-    # Look up the appropriate converter class
     if model_arch not in _MODEL_REGISTRY:
         available = [ModelArchNames.get(arch, str(arch)) for arch in _MODEL_REGISTRY.keys()]
         raise ValueError(
@@ -1000,7 +1079,6 @@ def create_converter(gguf_path: str, override_model_arch:str) -> __Q4NX_Converte
         )
     
     converter_class = _MODEL_REGISTRY[model_arch]
-
     converter_instance = converter_class(reader)
 
     return converter_instance


### PR DESCRIPTION
**do not merge to main**

This may be worth merging to its own branch.  I don't have time to do an in-depth review though.  I have done a successful run on a 32GB model file with these changes but I have not extensively tested model output / behavior.

The changes are designed to use zero-copy and chunked disk offload during conversion.  Memory usage during conversion is about 1.2x model size, versus the original code requiring 2-2.5x.

The goal was to allow conversion of larger models without oom / crash.

If someone finds it useful, please pick it up and continue.