### PR TITLE
Fix phi4 conversions

### DIFF
--- a/q4nx/models/phi4.py
+++ b/q4nx/models/phi4.py
@@ -82,7 +82,5 @@ class Phi4(__Q4NX_Converter, model_arch=ModelArch.PHI4):
 
             self.q4nx_tensors[self.forward_name_map[gguf_tensor.name]] = self._pack_q4nx(*unpacked)
 
-        print(self.q4nx_tensors["rope.short.weight"])
-        print(self.q4nx_tensors["rope.long.weight"])
         self._export_q4nx_tensors(q4nx_path)
         self._extract_tokenizer_json(q4nx_path)


### PR DESCRIPTION
While converting some models, I attempted a phi4, and got this:
```bash
Traceback (most recent call last):
  File "/home/atomic-germ/Code/FLM_Q4NX_Converter/./convert.py", line 110, in <module>
    main()
  File "/home/atomic-germ/Code/FLM_Q4NX_Converter/./convert.py", line 55, in main
    convert_gguf_to_q4nx(input_path, output_folder, args.force_model_type, weights_type=args.weights_type)
  File "/home/atomic-germ/Code/FLM_Q4NX_Converter/./convert.py", line 10, in convert_gguf_to_q4nx
    model.convert(q4nx_path=q4nx_path, weights_type=weights_type)
  File "/home/atomic-germ/Code/FLM_Q4NX_Converter/q4nx/models/phi4.py", line 85, in convert
    print(self.q4nx_tensors["rope.short.weight"])
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'rope.short.weight'
```

So, I've removed the two lines that I *assume* were debug lines. It works now.