### PR TITLE
fix: correctly quantize linear-layer weights and embeddings for full-…

### DIFF
--- a/q4nx/gguf_tensor.py
+++ b/q4nx/gguf_tensor.py
@@ -202,12 +202,37 @@ class GGUFTensor:
             return default_tensor_type
 
     def unpack(self, default_tensor_type: GGMLQuantizationType) -> np.ndarray:
-        if self.tensor_type == GGMLQuantizationType.F32:
-            return [torch.Tensor(np.array(self.data.view(np.float32)))]
-        elif self.tensor_type == GGMLQuantizationType.F16:
-            return [torch.Tensor(np.array(self.data.view(np.float16).astype(np.float32)))]
-        elif self.tensor_type == GGMLQuantizationType.BF16:
-            return [torch.from_numpy(self.data.copy()).view(torch.bfloat16)]
+        # Native floating point tensor types (F32/F16/BF16) can only be
+        # returned as-is when the caller does NOT require a quantized
+        # target (e.g. norm weights, whose config entry sets
+        # default_tensor_type to a float type). If the caller requests a
+        # quantized target (Q4_0/Q4_1/Q8_0) -- which happens for ordinary
+        # matmul weights when the source GGUF stores every tensor in full
+        # precision (no per-tensor quantization at all) -- we must still
+        # quantize+pack the tensor into that format below. Otherwise the
+        # weight is left oversized and in the wrong (unpacked) layout,
+        # which the NPU runtime cannot read and crashes on.
+        is_native_float = self.tensor_type in (
+            GGMLQuantizationType.F32, GGMLQuantizationType.F16, GGMLQuantizationType.BF16
+        )
+        wants_quantized_target = default_tensor_type in (
+            GGMLQuantizationType.Q4_0, GGMLQuantizationType.Q4_1, GGMLQuantizationType.Q8_0
+        )
+        # The Q4_0/Q4_1/Q8_0 block-quantized formats only make sense for 2D
+        # matmul weight matrices; 1D tensors (e.g. rope_freqs, biases) are
+        # never packed this way even when a config entry is missing and
+        # falls back to the global default_tensor_type. Treat those as
+        # native float passthrough regardless of the requested target.
+        if len(self.shape) < 2:
+            wants_quantized_target = False
+
+        if is_native_float and not wants_quantized_target:
+            if self.tensor_type == GGMLQuantizationType.F32:
+                return [torch.Tensor(np.array(self.data.view(np.float32)))]
+            elif self.tensor_type == GGMLQuantizationType.F16:
+                return [torch.Tensor(np.array(self.data.view(np.float16).astype(np.float32)))]
+            else:  # BF16
+                return [torch.from_numpy(self.data.copy()).view(torch.bfloat16)]
 
         elif self.tensor_type == GGMLQuantizationType.Q4_0:
             return self.unpack_q4_0(self.data, self.shape[0])
@@ -219,14 +244,23 @@ class GGUFTensor:
             return self.unpack_mxfp4(self.data, self.shape[0])
         else:
             """
-                If the tensor type is not supported, try to dequantize it and then quantize it back to Q4_1
-                This is a workaround for the fact that the GGUF format does not support all tensor types
-                and we need to convert it to a supported type before converting to Q4NX
+                If the tensor type is not natively packable as-is (either a
+                truly unsupported GGUF quant type such as Q4_K/Q5_K/Q6_K, or
+                a native F32/F16/BF16 tensor that the caller wants quantized
+                to a Q4_0/Q4_1/Q8_0 target), dequantize it (gguf.dequantize
+                already handles F32/F16/BF16 as a passthrough/cast) and then
+                quantize it to default_tensor_type before packing.
             """
             try:
                 w = dequantize(self.data, self.tensor_type)
                 w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-                
+
+                if default_tensor_type == GGMLQuantizationType.BF16:
+                    # BF16 is not a quantized format, so no requantization is
+                    # needed: just return the dequantized tensor directly,
+                    # consistent with the native BF16 branch above.
+                    return [w]
+
                 w = w.to(torch.float32).numpy()
                 data_quantized = quantize(w, default_tensor_type).copy()
                 if default_tensor_type == GGMLQuantizationType.Q4_1:

--- a/q4nx/models/gemma4.py
+++ b/q4nx/models/gemma4.py
@@ -24,6 +24,40 @@ class Gemma4(__Q4NX_Converter, model_arch=ModelArch.GEMMA4):
     
     
     
+    def _quantize_embedding_int8(self, weight: torch.Tensor, group_size: int = 32):
+        """
+        Quantize an embedding-table weight (rows=vocab, cols=hidden) into
+        the plain per-row / per-group symmetric int8 format expected by
+        the FLM runtime for lookup-style tensors (as opposed to the
+        packed block format used for matmul weights).
+
+        For every row, the columns are split into contiguous groups of
+        `group_size` elements. Each group gets its own scale:
+            scale = max(|group|) / 127
+            q = round(group / scale), clamped to [-127, 127]
+
+        Returns
+        -------
+        (q4nx_weight, q4nx_scale) : Tuple[torch.Tensor, torch.Tensor]
+            q4nx_weight: int8 tensor of shape (rows, cols)
+            q4nx_scale:  float32 tensor of shape (rows, cols // group_size)
+        """
+        assert weight.ndim == 2, "Embedding weight must be a 2D matrix"
+        rows, cols = weight.shape
+        assert cols % group_size == 0, f"Embedding hidden size {cols} must be divisible by group_size {group_size}"
+
+        w = weight.to(torch.float32)
+        w_grouped = w.view(rows, cols // group_size, group_size)
+
+        amax = w_grouped.abs().amax(dim=-1)
+        scale = (amax / 127.0).clamp(min=1e-8)
+
+        q = torch.round(w_grouped / scale.unsqueeze(-1)).clamp(-127, 127).to(torch.int8)
+        q = q.reshape(rows, cols).contiguous()
+        scale = scale.to(torch.float32).contiguous()
+
+        return q, scale
+
     def reshape_matrix_to_block_matrix_for_mvm(self, weight: torch.Tensor, row_block_size: int=32) -> torch.Tensor:
         """
             Assume the weights is a 2D matrix of W x H
@@ -68,17 +102,23 @@ class Gemma4(__Q4NX_Converter, model_arch=ModelArch.GEMMA4):
                 self.q4nx_tensors["lm_head.weight"] = self._pack_q4nx(*unpacked)      
 
             for key, gguf_tensor in self.gguf_tensors.items():
-                if "token_embd.weight"  == gguf_tensor.name: # this should be bf16
+                if "token_embd.weight"  == gguf_tensor.name:
                     w = dequantize(gguf_tensor.data, gguf_tensor.tensor_type)
                     w = w * float(self.hidden_size) **0.5
-                    w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-                    self.q4nx_tensors[self.forward_name_map[gguf_tensor.name]] = w
+                    w = torch.from_numpy(w).contiguous()
+                    q_w, scale = self._quantize_embedding_int8(w)
+                    name = self.forward_name_map[gguf_tensor.name]
+                    self.q4nx_tensors[name] = q_w
+                    self.q4nx_tensors[f"{name}.scale"] = scale
                     continue
                 elif "per_layer_token_embd.weight"  ==  gguf_tensor.name:
                     w = dequantize(gguf_tensor.data, gguf_tensor.tensor_type)
                     w = w*float(self.embedding_length_per_layer_input)**0.5
-                    w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-                    self.q4nx_tensors[self.forward_name_map[gguf_tensor.name]] = w
+                    w = torch.from_numpy(w).contiguous()
+                    q_w, scale = self._quantize_embedding_int8(w)
+                    name = self.forward_name_map[gguf_tensor.name]
+                    self.q4nx_tensors[name] = q_w
+                    self.q4nx_tensors[f"{name}.scale"] = scale
                     continue
                 elif "per_layer_model_proj.weight" in gguf_tensor.name:
                     unpacked = gguf_tensor.unpack(self.tensor_q4nx_type_map[gguf_tensor.name])


### PR DESCRIPTION
…precision (BF16) GGUF sources

- gguf_tensor.py: unpack() previously returned native F32/F16/BF16 tensors as-is regardless of the requested default_tensor_type. When the entire source GGUF is BF16 (no per-tensor quantization applied by llama.cpp), this caused linear weights (mlp.up_proj/gate_proj/ down_proj, lm_head.weight, q_proj, etc.) that should be packed to Q4_1 per the model config to instead be left as raw oversized BF16 tensors in the wrong layout, crashing the FLM runtime (access violation in VCRUNTIME140.dll) on load. Now unpack() only takes the float passthrough path when the requested default_tensor_type is not itself a quantized target (Q4_0/Q4_1/Q8_0); otherwise it dequantizes and feeds into the existing quantize+pack path. 1D tensors (e.g. rope_freqs) are excluded since block quantization only applies to 2D matmul weights.

- gemma4.py: add _quantize_embedding_int8() and use it for token_embd.weight / per_layer_token_embd.weight so embedding tables are exported as int8 + per-32-group F32 scale, matching the format expected by the FLM runtime instead of raw BF16.

Verified: BF16-source conversion now produces a model.q4nx that is byte-identical in size and has identical tensor dtypes/shapes (709/709 match) to FLM's official reference Q4NX package, and loads/runs correctly. 