### PR TITLE
Drop the zero bias block from Q8_0 packing

### DIFF
--- a/q4nx/model_converter.py
+++ b/q4nx/model_converter.py
@@ -633,10 +633,11 @@ class __Q4NX_Converter(ABC):
             m_np = m.numpy()            
             merged = np.concatenate([scales_np,  m_np, data_np], axis = -1).copy()
         else:
-            # We pack to q8nx, if there is no bias, we provide a fake bias of all zero
-            # create a zero npy array of scale shape
-            zero_np = np.zeros_like(scales_np)
-            merged = np.concatenate([scales_np, zero_np,  data_np], axis = -1).copy()
+            # Q8_0 has no bias term, and FastFlowLM's own builds do not reserve
+            # space for one: a 32x256 block is 512 bytes of scales + 8192 bytes of
+            # data = 8704, which is what every published Qwen3.5 q4nx has. Emitting
+            # a zero bias block here makes it 9216 and the model will not load.
+            merged = np.concatenate([scales_np, data_np], axis = -1).copy()
         return torch.from_numpy(merged)       
     
     def _pack_q4nx(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None) -> torch.Tensor:


### PR DESCRIPTION
Q8_0 has no bias term, but _pack_q8nx reserved space for one anyway, emitting scales + zeros + data. FastFlowLM's own builds do not: a 32x256 block is 512 bytes of scales plus 8192 of data = 8704, and the placeholder made it 9216.

The mismatch is invisible until the model is loaded. The file is valid safetensors with every expected tensor name and a plausible size, and the runtime then exits during load without printing anything, because the NPU kernels are compiled for a fixed tile layout.

Verified against FastFlowLM/Qwen3.5-9B-NPU2: converting the stock Qwen/Qwen3.5-9B now reproduces the published model.q4nx byte-for-byte in size with all 475 tensors matching shape and dtype, and it generates coherent text on an XDNA2 NPU. Also checked against the published 0.8B, 2B and 4B builds, which all use the 8704 layout.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
