### PR TITLE
Mix precision

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
      
     #sys.argv = ['convert.py', '-i', 'qwen3_5vl-9bmmproj-BF16.gguf', '-o', 'unsloth-qwen3_5_9bvl-vision', '-t', 'vision'] 
     
-    
+    sys.argv = ['convert.py', '-i', 'Qwen3.5-0.8B-Q4_1.gguf', '-o', 'unsloth-qwen3_5_0.8bq41']
     #sys.argv = ['convert.py', '-i', 'Qwen3.5-4B-Q4_1.gguf', '-o', 'unsloth-qwen3_5_4bq41'] 
     
     #sys.argv = ['convert.py', '-i', 'Qwen3.5-9B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf', '-o', 'unsloth-qwen3_59b_uncensored', "-f", "qwen3.5-9B"]     
@@ -105,6 +105,6 @@ if __name__ == "__main__":
     
     #sys.argv = ['convert.py', '-i', 'gemma4-2b-mmproj.gguf', '-o', 'unsloth-gemma4-2b-vision', '-t', 'vision']     
     
-    sys.argv = ['convert.py', '-i', 'gemma4-2b-mmproj.gguf', '-o', 'unsloth-gemma4-2b-audio', '-t', 'audio']         
+    #sys.argv = ['convert.py', '-i', 'gemma4-2b-mmproj.gguf', '-o', 'unsloth-gemma4-2b-audio', '-t', 'audio']         
     # sys.argv = ['convert.py', '-i', 'debug_gemma4e2b_model.gguf', '-o', 'debug-gemma4-2b-audio', '-t', 'audio', '-f', 'gemma4']           
     main()

--- a/q4nx/model_converter.py
+++ b/q4nx/model_converter.py
@@ -633,10 +633,11 @@ class __Q4NX_Converter(ABC):
             m_np = m.numpy()            
             merged = np.concatenate([scales_np,  m_np, data_np], axis = -1).copy()
         else:
-            # We pack to q8nx, if there is no bias, we provide a fake bias of all zero
-            # create a zero npy array of scale shape
-            zero_np = np.zeros_like(scales_np)
-            merged = np.concatenate([scales_np, zero_np,  data_np], axis = -1).copy()
+            # Q8_0 has no bias term, and FastFlowLM's own builds do not reserve
+            # space for one: a 32x256 block is 512 bytes of scales + 8192 bytes of
+            # data = 8704, which is what every published Qwen3.5 q4nx has. Emitting
+            # a zero bias block here makes it 9216 and the model will not load.
+            merged = np.concatenate([scales_np, data_np], axis = -1).copy()
         return torch.from_numpy(merged)       
     
     def _pack_q4nx(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None) -> torch.Tensor:

--- a/q4nx/model_converter.py
+++ b/q4nx/model_converter.py
@@ -408,95 +408,101 @@ class __Q4NX_Converter(ABC):
         
     
   
-    def force_pack_q8_to_q4nx_size(self, tensor_data:GGUFTensor):
+    # def force_pack_q8_to_q4nx_size(self, tensor_data:GGUFTensor):
         
-            # TODO: FIXME: DEBUG force convert Q80
-            w = dequantize(tensor_data.data, tensor_data.tensor_type)
-            w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
-            print(w)
-            w = w.to(dtype=torch.float32).numpy()
+    #         # TODO: FIXME: DEBUG force convert Q80
+    #         w = dequantize(tensor_data.data, tensor_data.tensor_type)
+    #         w = torch.from_numpy(w).contiguous().to(torch.bfloat16)
+    #         print(w)
+    #         w = w.to(dtype=torch.float32).numpy()
             
-            data_q80 = quantize(w, GGMLQuantizationType.Q8_0).copy()
-            # create a new GGUF type
-            data_q80_gguf = GGUFTensor("data_q80", data_q80.shape, data_q80, GGMLQuantizationType.Q8_0)
+    #         data_q80 = quantize(w, GGMLQuantizationType.Q8_0).copy()
+    #         # create a new GGUF type
+    #         data_q80_gguf = GGUFTensor("data_q80", data_q80.shape, data_q80, GGMLQuantizationType.Q8_0)
                         
-            unpacked =data_q80_gguf.unpack(self.default_tensor_type)
+    #         unpacked =data_q80_gguf.unpack(self.default_tensor_type)
 
             
-            # override to turn keep_block_in_2D = True
-            old_keep_block_in_2D =  self.keep_block_in_2D
-            self.keep_block_in_2D = True
-            val = self._pack_q4nx_8b(*unpacked)
-            self.keep_block_in_2D = old_keep_block_in_2D
+    #         # override to turn keep_block_in_2D = True
+    #         old_keep_block_in_2D =  self.keep_block_in_2D
+    #         self.keep_block_in_2D = True
+    #         val = self._pack_q4nx_8b(*unpacked)
+    #         self.keep_block_in_2D = old_keep_block_in_2D
             
-            return val
-            # scales, data = GGUFTensor.unpack_q8_0( data_q80)
+    #         return val
+    #         # scales, data = GGUFTensor.unpack_q8_0( data_q80)
             
-            # m_tmp = scales.clone()
+    #         # m_tmp = scales.clone()
             
-            # # override 
+    #         # # override 
 
-            # col_block_size_old = self.col_block_size
-            # keep_block_in_2D_old = self.keep_block_in_2D
+    #         # col_block_size_old = self.col_block_size
+    #         # keep_block_in_2D_old = self.keep_block_in_2D
             
-            # cur_q4nx_block_byte_size = int(( self.row_block_size* col_block_size_old   )*(5/8) )
+    #         # cur_q4nx_block_byte_size = int(( self.row_block_size* col_block_size_old   )*(5/8) )
             
-            # if col_block_size_old == 256:
-            #     self.col_block_size= 128
-            # else:
-            #     #TODO:
-            #     raise ValueError("Undefine case for now")
-            # self.keep_block_in_2D= True
-            # q8nx_pack_result  = self._pack_q8nx(
-            #     scales, m_tmp, data
-            # )
+    #         # if col_block_size_old == 256:
+    #         #     self.col_block_size= 128
+    #         # else:
+    #         #     #TODO:
+    #         #     raise ValueError("Undefine case for now")
+    #         # self.keep_block_in_2D= True
+    #         # q8nx_pack_result  = self._pack_q8nx(
+    #         #     scales, m_tmp, data
+    #         # )
             
-            # # now, we want to padd the last dimension to be size of 5120(for q4nx)
-            # # Pad the last dimension from 4608 to 5120
+    #         # # now, we want to padd the last dimension to be size of 5120(for q4nx)
+    #         # # Pad the last dimension from 4608 to 5120
 
             
-            # padding_size = cur_q4nx_block_byte_size    - q8nx_pack_result.shape[-1]
-            # q8nx_pack_result = F.pad(q8nx_pack_result, (0, padding_size))
+    #         # padding_size = cur_q4nx_block_byte_size    - q8nx_pack_result.shape[-1]
+    #         # q8nx_pack_result = F.pad(q8nx_pack_result, (0, padding_size))
             
-            # self.keep_block_in_2D = keep_block_in_2D_old
-            # self.col_block_size = col_block_size_old
-            # return q8nx_pack_result
+    #         # self.keep_block_in_2D = keep_block_in_2D_old
+    #         # self.col_block_size = col_block_size_old
+    #         # return q8nx_pack_result
             
             
     def _pack(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None, tensor_type: GGMLQuantizationType = None) -> torch.Tensor:
+        #TODO: do not support q81
         if tensor_type == GGMLQuantizationType.Q8_0:
-            return self._pack_q4nx_8b(d, m, qw)
+            return self._pack_q8nx(d, None, qw )
+        elif tensor_type == GGMLQuantizationType.Q8_1:
+            return self._pack_q8nx(d, m, qw )
         else:
             return self._pack_q4nx(d, m, qw)
         
     
-    def _pack_q4nx_8b(self,  d: torch.Tensor,m: torch.Tensor, qw:torch.Tensor) -> torch.Tensor:
-        #note, support q80 for now
-        # d for scale
-        # m for min
+    # def _pack_q4nx_8b(self,  d: torch.Tensor,m: torch.Tensor, qw:torch.Tensor) -> torch.Tensor:
+    #     #note, support q80 for now
+    #     # d for scale
+    #     # m for min
         
-        # TODO: NOTE:
-        col_block_size_old = self.col_block_size
-        keep_block_in_2D_old = self.keep_block_in_2D        
-        if self.col_block_size == 256:
-            # force to 128 
-            self.col_block_size= 128            
-        else:
-            raise ValueError("Undefine case for now")
-        self.keep_block_in_2D= True
+    #     # TODO: NOTE:
+    #     col_block_size_old = self.col_block_size
+    #     keep_block_in_2D_old = self.keep_block_in_2D        
+    #     if self.col_block_size == 256:
+    #         # force to 128 
+    #         self.col_block_size= 128            
+    #     else:
+    #         raise ValueError("Undefine case for now")
+    #     self.keep_block_in_2D= True
         
-        cur_q4nx_block_byte_size = int(( self.row_block_size* col_block_size_old   )*(5/8) )
+    #     cur_q4nx_block_byte_size = int(( self.row_block_size* col_block_size_old   )*(5/8) )
                     
-        q8nx_pack_result = self._pack_q8nx(data=qw, scales=d, m = m )
+    #     q8nx_pack_result = self._pack_q8nx(data=qw, scales=d, m = m )
 
-        padding_size = cur_q4nx_block_byte_size    - q8nx_pack_result.shape[-1]
-        q8nx_pack_result = F.pad(q8nx_pack_result, (0, padding_size))
+    #     padding_size = cur_q4nx_block_byte_size    - q8nx_pack_result.shape[-1]
+    #     q8nx_pack_result = F.pad(q8nx_pack_result, (0, padding_size))
         
-        self.keep_block_in_2D = keep_block_in_2D_old
-        self.col_block_size = col_block_size_old
-        return q8nx_pack_result
+    #     self.keep_block_in_2D = keep_block_in_2D_old
+    #     self.col_block_size = col_block_size_old
+    #     return q8nx_pack_result
         
-    def _pack_q8nx(self,  data: torch.Tensor,scales: torch.Tensor, m:torch.Tensor) -> torch.Tensor:
+    def _pack_q8nx(self,   d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None) -> torch.Tensor:
+        scales = d
+
+        data=qw
         #note, support q80 for now
         """ Q8NX format similar to Q4NX
 
@@ -533,12 +539,15 @@ class __Q4NX_Converter(ABC):
         
         if scales.shape[-1] == 1:
             scales = scales.reshape(*scales.shape[:-2], -1).contiguous()
+        if data.shape[-1] == 1:
             data = data.reshape(*data.shape[:-2], -1).contiguous()
+        if m is not None and  m.shape[-1] == 1: 
             m = m.reshape(*m.shape[:-2], -1).contiguous()
         else:
             scales = scales.contiguous()
             data = data.contiguous()
-            m = m.contiguous() 
+            if m is not None:
+                m = m.contiguous() 
             
         rows, cols = data.shape[0], data.shape[1]
         
@@ -552,7 +561,8 @@ class __Q4NX_Converter(ABC):
             data_pad_amount = cols_padded - cols
             
             scales = F.pad(scales, (0, scale_pad_amount), "constant", 0)
-            m = F.pad(m, (0, scale_pad_amount), "constant", 0)
+            if m is not None:
+                m = F.pad(m, (0, scale_pad_amount), "constant", 0)
             data = F.pad(data, (0, data_pad_amount), "constant", 0)
         
 
@@ -570,13 +580,14 @@ class __Q4NX_Converter(ABC):
 
             ).contiguous()
             
-            m = rearrange(
-                m,
-                "(row_div_r r) (col_div_c c) -> row_div_r col_div_c (c r)",
-                r=self.row_block_size,
-                c=self.col_block_size // Q8_group_size                
-            ).contiguous()
-            
+            if m is not None:
+                m = rearrange(
+                    m,
+                    "(row_div_r r) (col_div_c c) -> row_div_r col_div_c (c r)",
+                    r=self.row_block_size,
+                    c=self.col_block_size // Q8_group_size                
+                ).contiguous()
+                
             assert self.row_block_size % self.parallel_size == 0
             # similar, for the data block
             data = rearrange(
@@ -601,23 +612,31 @@ class __Q4NX_Converter(ABC):
             scales = scales.to(torch.bfloat16)
             
             # also convert m from float16 to bfloat16
-            assert(m.dtype == torch.float16)
-            m = m.to(torch.bfloat16)
-        
+            if m is not None:
+                assert(m.dtype == torch.float16)
+                m = m.to(torch.bfloat16)
+            
             
         else:
             raise ValueError("Only support keep_block_in_2D for now")
         
         scales = scales.view(torch.int8)
-        m = m.view(torch.int8)
+        if m is not None:
+            m = m.view(torch.int8)
         data = data.view(torch.int8)
         
         scales_np = scales.numpy()
-        m_np = m.numpy()
+
         data_np = data.numpy()
-        # do  a copy of scales_np for now, for padding space
-        merged = np.concatenate([scales_np,  m_np, data_np], axis = -1).copy()
         
+        if m is not None:
+            m_np = m.numpy()            
+            merged = np.concatenate([scales_np,  m_np, data_np], axis = -1).copy()
+        else:
+            # We pack to q8nx, if there is no bias, we provide a fake bias of all zero
+            # create a zero npy array of scale shape
+            zero_np = np.zeros_like(scales_np)
+            merged = np.concatenate([scales_np, zero_np,  data_np], axis = -1).copy()
         return torch.from_numpy(merged)       
     
     def _pack_q4nx(self, d: torch.Tensor, m: torch.Tensor = None, qw: torch.Tensor = None) -> torch.Tensor:


### PR DESCRIPTION
## Motivation

> **Base:** this branch is `ROCm/FLM_Q4NX_Converter@mix-precision`
> (`038e67e break: q8nx standard`) with **one commit on top**. That branch is the
> starting point and does the larger half of the work; this PR adds the last
> piece and targets `main` so the fix reaches users of the default branch.

`main` cannot currently produce a loadable `model.q4nx` for any published Qwen3.5
build. The converter runs to completion and writes a file that looks entirely
correct — valid safetensors, every expected tensor name, a size within 0.15 % of
the official build — and FastFlowLM then exits during model load **without
printing anything**, because the NPU kernels are compiled for a fixed tile
layout.

Two changes are needed to close the gap:

1. **`038e67e break: q8nx standard`** — yours, from `mix-precision`, unmerged as
   of this writing. It routes Q8_0 through `_pack_q8nx` instead of
   `_pack_q4nx_8b`, which stops `col_block_size` being forced 256 → 128 and
   padded up to the Q4_1 block size. That alone moves the middle dimension from
   32 to 16, matching FastFlowLM. Carried here unchanged; all credit yours.
2. **`e5cfd3a`** — the only new commit in this PR. One leftover remained in that
   path: Q8_0 has no bias term, but `_pack_q8nx` still reserves space for one, so
   `mix-precision` on its own still produces a file that will not load.

If you would rather land these separately, merging `mix-precision` first and then
taking `e5cfd3a` on top gives the same result — the two are independent edits to
the same function.

## Technical Details

`_pack_q8nx` emits a placeholder bias block when `m is None`:

```python
# We pack to q8nx, if there is no bias, we provide a fake bias of all zero
zero_np = np.zeros_like(scales_np)
merged = np.concatenate([scales_np, zero_np, data_np], axis=-1)
```

FastFlowLM's own builds reserve no such space. For a 32 × 256 block:

```
data    32 rows x 256 cols x 1 byte           = 8192
scales  (256/32 groups) x 32 rows x 2 bytes   =  512
                                        total =  8704   ← every published build
with the zero bias block                      =  9216   ← what main produces
```

The change drops the placeholder, leaving `[scales, data]`.

For `configs/qwen3.5_9b.json` this affects the four tensor families carrying
`"default_tensor_type": "Q8_0"` — `linear_alpha_proj`, `linear_beta_proj`,
`linear_out_proj` and `lm_head`. That is 24 GatedDeltaNet layers × 3 plus the
output head = **73 of 475 tensors**. The other 402 (Q4_1) were already correct on
`main`, which is why the size difference is small enough to be easy to miss.

The `8704` figure is not specific to the 9B — it holds across the whole published
Qwen3.5 line (see Test Result).

## Test Plan

Converted the stock `Qwen/Qwen3.5-9B` and compared the output against the
published `FastFlowLM/Qwen3.5-9B-NPU2`:

```bash
# HF -> F16 GGUF. --no-mtp because llama.cpp exports the multi-token-prediction
# head as a 33rd block, and the q4nx name_map has no entry for nextn.*
python llama.cpp/convert_hf_to_gguf.py Qwen3.5-9B --outfile model-f16.gguf \
  --outtype f16 --no-mtp

# F16 -> Q4_1. The per-tensor Q8_0 overrides matter: the converter packs each
# tensor at the type it actually finds, so a blanket Q4_1 source yields the
# wrong layout for exactly the 73 tensors above.
llama-quantize --tensor-type ssm_alpha=q8_0 --tensor-type ssm_beta=q8_0 \
               --tensor-type ssm_out=q8_0 --output-tensor-type q8_0 \
               model-f16.gguf model-q4_1.gguf Q4_1

# Q4_1 -> q4nx. Architecture forced: llama.cpp writes
# general.architecture = "qwen35", which substring-matches the plain "qwen3"
# entry and loads configs/qwen3.json.
python -c "from q4nx import create_converter; \
  create_converter('model-q4_1.gguf', 'qwen3.5-9B').convert( \
  q4nx_path='out', weights_type='language')"
```

`model.q4nx` is a safetensors file, so the header can be compared directly —
including against published builds over HTTP range requests, without downloading
7 GB:

```python
import json, struct, urllib.request
url = "https://huggingface.co/FastFlowLM/Qwen3.5-9B-NPU2/resolve/main/model.q4nx"
n = struct.unpack('<Q', urllib.request.urlopen(
        urllib.request.Request(url, headers={"Range": "bytes=0-7"})).read(8))[0]
hdr = json.loads(urllib.request.urlopen(
        urllib.request.Request(url, headers={"Range": f"bytes=8-{8+n-1}"})).read(n))
print(hdr["lm_head.weight"]["shape"])     # [7760, 16, 8704]
```

Then loaded the result on hardware: Ryzen AI 9 HX 370 (XDNA2), FastFlowLM
0.9.4x, registered as a separate model alongside the stock one.

## Test Result

**Layout matches the published build exactly.**

```
official FastFlowLM/Qwen3.5-9B-NPU2 : 7,632,668,880 bytes
this PR                             : 7,632,668,880 bytes
tensors                             : 475 / 475 matching name, shape and dtype
```

Before the fix, those 73 tensors were `[…, 16, 9216]` against the expected
`[…, 16, 8704]`; on unmodified `main` they were `[…, 32, 5120]`.

**The 8704 layout is consistent across every published Qwen3.5 build**, read from
their safetensors headers:

| build | `lm_head` (Q8_0) | `ssm_out` (Q8_0) | `down_proj` (Q4_1) |
| --- | --- | --- | --- |
| 0.8B | `[7760, 4, 8704]` | `[32, 8, 8704]` | `[32, 14, 5120]` |
| 2B | `[7760, 8, 8704]` | `[64, 8, 8704]` | `[64, 24, 5120]` |
| 4B | `[7760, 10, 8704]` | `[80, 16, 8704]` | `[80, 36, 5120]` |
| 9B | `[7760, 16, 8704]` | `[128, 16, 8704]` | `[128, 48, 5120]` |

**Runs on the NPU.** Coherent multilingual generation, correct code-switching, no
repetition or token corruption:

```
>>> Kan du ikke snakke norsk, da?
Ja, jeg snakker norsk! Jeg kan hjelpe deg med å svare på spørsmål, skrive
tekster, oversette eller bare ha en samtale.
```

This last check matters beyond "it loads": matching shapes only prove the
container is right. A wrong element ordering inside each Q8 block would also
load and then emit fluent nonsense.

**Also verified on modified weights.** A LoRA fine-tune of the same base, merged
with `llama-export-lora`, converts to a `model.q4nx` of identical size with all
475 tensors matching — as expected, since a LoRA merge only touches Q4_1 tensors
and leaves the 73 Q8_0 ones untouched.

For reference, the one locally-installed model with the old 5120-wide Q8_0
layout is a Qwen3.5-4B at `flm_version 0.9.36`, which current FastFlowLM already
refuses:

```
[FLM] Local model qwen3.5:4b version: 0.9.36 < 0.9.45
[FLM] Model qwen3.5:4b is not compatible with the current FLM version.
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests